### PR TITLE
Multiple SRN feature

### DIFF
--- a/.github/workflows/deploy_to_s3_staging.yml
+++ b/.github/workflows/deploy_to_s3_staging.yml
@@ -41,7 +41,7 @@ jobs:
         VUE_APP_AWS_SECRET_KEY: ${{ secrets.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY }}
         VUE_APP_BASE_URL_MEET: 'https://meet.google.com/'
 
-      run: npm run build --mode staging
+      run: npm run build
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy_to_s3_staging.yml
+++ b/.github/workflows/deploy_to_s3_staging.yml
@@ -34,14 +34,14 @@ jobs:
     # build the vuepress docs
     - name: Build
       env:
-        NODE_ENV: staging
+        NODE_ENV: production
         VUE_APP_AF_API_KEY: ${{ secrets.VUE_APP_AF_API_KEY }}
         VUE_APP_BASE_URL_PLIO: 'https://staging-app.plio.in/#/af/play/'
         VUE_APP_AWS_ACCESS_KEY_ID: ${{ secrets.VUE_APP_AWS_SQS_ACCESS_KEY }}
         VUE_APP_AWS_SECRET_KEY: ${{ secrets.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY }}
         VUE_APP_BASE_URL_MEET: 'https://meet.google.com/'
 
-      run: npm run build
+      run: npm run build --mode staging
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>AF_favicon.png">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
     <title>Avanti Login</title>
   </head>
   <body>

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -34,17 +34,12 @@
         invalidLoginMessage
       }}</span>
 
-<<<<<<< HEAD
+
       <div class="flex flex-row my-auto multiple-div" v-if="isAddButtonAllowed">
         <button @click="addField" class="addButtonStyleClass">
           <span class="material-icons addButton"> add_box </span>
           Add another SRN <br />
           एक और SRN दर्ज करें
-=======
-      <div class="flex flex-row my-auto multiple-div" v-if="isUserValidated">
-        <button @click="addField(userIDList)" class="addButtonStyleClass">
-          Add another SRN / एक और SRN दर्ज करें
->>>>>>> e3c51f09b5d9b31d8178a09c5d9ad3a051a12072
         </button>
       </div>
       <button

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -18,13 +18,14 @@
           class="inputStyleClass"
           @input="updateValue($event, index)"
         />
-        <div
-          class="minus-sign"
+
+        <button
+          class="material-icons minusButton"
           v-show="ifUserEnteredMoreThanOne"
           @click="removeField(index, userIDList)"
         >
-          <span class="material-icons minusButton"> remove_circle </span>
-        </div>
+          remove_circle
+        </button>
       </div>
 
       <span class="errorStyleClass" v-if="invalidInputMessage">{{
@@ -33,18 +34,14 @@
       <span class="errorStyleClass" v-if="!isUserValid && validateCount == 1">{{
         invalidLoginMessage
       }}</span>
-
-<<<<<<< HEAD
+      <div v-if="isLoading" class="loadingSpinner"></div>
       <div class="flex flex-row my-auto multiple-div" v-if="isAddButtonAllowed">
         <button @click="addField" class="addButtonStyleClass">
           <span class="material-icons addButton"> add_box </span>
-          Add another SRN <br />
-          एक और SRN दर्ज करें
-=======
-      <div class="flex flex-row my-auto multiple-div" v-if="isUserValidated">
-        <button @click="addField(userIDList)" class="addButtonStyleClass">
-          Add another SRN / एक और SRN दर्ज करें
->>>>>>> e3c51f09b5d9b31d8178a09c5d9ad3a051a12072
+          <p>
+            Add another SRN <br />
+            एक और SRN दर्ज करें
+          </p>
         </button>
       </div>
       <button
@@ -81,6 +78,7 @@ export default {
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
       invalidLoginMessage: "Please enter correct SRN / कृपया सही SRN दर्ज करें",
+      isLoading: false,
     };
   },
   computed: {
@@ -128,11 +126,7 @@ export default {
     },
   },
   methods: {
-<<<<<<< HEAD
     isValidNumericEntry(e) {
-=======
-    allowNumericEntriesOnly(e) {
->>>>>>> e3c51f09b5d9b31d8178a09c5d9ad3a051a12072
       //checking to see if each char typed by user is only a number
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();
@@ -199,6 +193,7 @@ export default {
     },
     //method that authentiates the SRN
     async authenticateSRN(userID) {
+      this.isLoading = true;
       //invokes the validation function
       let userValidationResponse = await validateSRN(
         userID,
@@ -213,10 +208,12 @@ export default {
       this.isUserValid = userValidationResponse.isUserValid;
       this.validateCount = userValidationResponse.validateCount;
       this.invalidLoginMessage = userValidationResponse.invalidLoginMessage;
+      this.isLoading = false;
     },
     //method called after clicking the submit button
     async processForm() {
       var authType = "SRN";
+
       //all previously typed SRN's will be authenticated through the addField method.
       // The last SRN will be authenticated after Submit button is clicked
       // (will work even for single entry as the first entry can be also considered as the last entry)
@@ -279,5 +276,8 @@ label {
 }
 .minusButton {
   @apply text-red-500;
+}
+.loadingSpinner {
+  @apply mx-auto w-4 h-4 border-4 border-primary border-dotted rounded-full animate-spin;
 }
 </style>

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -105,7 +105,7 @@ export default {
     },
   },
   methods: {
-    isValidSRNFormat(e) {
+    allowNumericEntriesOnly(e) {
       //checking to see if each char typed by user is only a number
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -155,7 +155,7 @@ export default {
     //method that authentiates the SRN
     async authenticateSRN(userID) {
       //invokes the validation function
-      let userIsValidated = await validateSRN(
+      let userValidationResponse = await validateSRN(
         userID,
         this.validateCount,
         this.isSingleEntryOnly,

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -85,7 +85,6 @@ export default {
     isAnyUserIDPresent() {
       //checks if any userID has been typed
       return (
-        this.userIDList != null &&
         this.userIDList != undefined &&
         this.userIDList.length > 0 &&
         this.userIDList[0]["userID"] != ""

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -9,7 +9,7 @@
       >
         <input
           v-model="input.userID"
-          type="text"
+          type="tel"
           inputmode="numeric"
           pattern="[0-9]*"
           placeholder="Your SRN / आपका SRN"

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -123,11 +123,7 @@ export default {
     },
   },
   methods: {
-<<<<<<< HEAD
-    isValidNumericEntry(e) {
-=======
     allowNumericEntriesOnly(e) {
->>>>>>> e3c51f09b5d9b31d8178a09c5d9ad3a051a12072
       //checking to see if each char typed by user is only a number
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -34,7 +34,6 @@
 
       <div class="flex flex-row my-auto multiple-div" v-if="isUserValidated">
         <button @click="addField(userIDList)" class="addButtonStyleClass">
-          <div class="plus-sign mr-3" @click="addField(index, userIDList)"></div>
           Add another SRN / एक और SRN दर्ज करें
         </button>
       </div>

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -16,10 +16,15 @@
           required
           @keypress="isValidSRNFormat($event)"
           class="inputStyleClass"
-          @input="updateValue"
+          @input="updateValue($event, index)"
         />
-       </div>
-       
+        <div
+          class="minus-sign"
+          v-show="ifUserEnteredMoreThanOne"
+          @click="removeField(index, userIDList)"
+        ></div>
+      </div>
+
       <span class="errorStyleClass" v-if="invalidInputMessage">{{
         invalidInputMessage
       }}</span>
@@ -27,6 +32,12 @@
         invalidLoginMessage
       }}</span>
 
+      <div class="flex flex-row my-auto multiple-div" v-if="isUserValidated">
+        <button @click="addField(userIDList)" class="addButtonStyleClass">
+          <div class="plus-sign mr-3" @click="addField(index, userIDList)"></div>
+          Add another SRN / एक और SRN दर्ज करें
+        </button>
+      </div>
       <button
         @click="processForm"
         class="buttonStyleClass"
@@ -52,8 +63,8 @@ export default {
   },
   data() {
     return {
-      userIDList: [{ userID: "" }],
-      invalidInputMessage: null,
+      userIDList: [{ userID: "", valid: false }], //array containing user-id's and a valid flag for each
+      invalidInputMessage: null, //flag to check if the input is in correct format
       isUserValid: false, // whether the user exists in the backend database
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
@@ -78,49 +89,73 @@ export default {
       return this.redirectTo == "plio";
     },
     isSubmitButtonDisabled() {
-      return !this.isAnyUserIDPresent || this.invalidInputMessage != "";
+      //submit button is disabled if no SRN has been typed or input is invalid or SRN hasn't been completely typed
+      return (
+        !this.isAnyUserIDPresent ||
+        this.invalidInputMessage != "" ||
+        this.userIDList.slice(-1)[0]["userID"].length < this.maxLengthOfSRN - 1
+      );
     },
     isUserValidated() {
       //if multiple SRN's are allowed, then this helps with the activation of the + button, to add more SRN's
       return (
         !this.isSingleEntryOnly &&
-        this.userIDList[0]["userID"].length > this.maxLengthOfSRN - 1
+        this.userIDList.slice(-1)[0]["userID"].length > this.maxLengthOfSRN - 1 &&
+        this.userIDList.length < 10
       );
     },
   },
   methods: {
     isValidSRNFormat(e) {
       //checking to see if each char typed by user is only a number
-      let char = String.fromCharCode(e.keyCode);
-      if (/^[0-9]+$/.test(char)) return true;
+      if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();
     },
-    addField(value, list) {
-      list.push({ value: "" });
+    async addField(list) {
+      //for adding another field, the previously entered ID is validated against the database
+      const userID = parseInt(this.userIDList.slice(-1)[0]["userID"]);
+      if (!isNaN(userID)) {
+        await this.authenticateSRN(userID);
+        //only if the SRN is valid or if the user is entering a SRN for the second time,the loop is entered
+        if (this.isUserValid || this.validateCount > 1) {
+          //setting the flag of the SRN
+          this.userIDList.slice(-1)[0]["valid"] = this.isUserValid;
+          list.push({ userID: "", valid: false });
+          //resetting flags to default for processing next SRN
+          this.isUserValid = false;
+          this.validateCount = 0;
+        }
+      }
     },
     removeField(index, list) {
+      //resetting all messages to default before deleting the input field
+      this.invalidInputMessage = "";
+      this.invalidLoginMessage = "";
+      //edge case: user enters an invalid SRN. Error message is displayed. The user is given another chance. User adds another input field but decided to remove it.
+      // At this point, the variables are reset. So the previously entered SRN is checked again, which should not happen. so setting this validateCount = 2 will bypass this.
+      //Will not affect any other case. The user can either submit or decide to add another field again.
+      this.validateCount = 2;
       list.splice(index, 1);
     },
-    updateValue(event) {
+    updateValue(event, index) {
+      //checks if the 10 characters are entered
       if (event.target.value.length < this.maxLengthOfSRN) {
         this.invalidInputMessage = "Please type 10 numbers / कृपया १० संख्या टाइप करें";
         this.invalidLoginMessage = "";
       } else {
         this.invalidInputMessage = "";
       }
+      //if more than 10 characters are entered, slicing the input to only 10
+      // index tells us which input field is being considered
       if (event.target.value.length > this.maxLengthOfSRN) {
         event.target.value = event.target.value.slice(0, this.maxLengthOfSRN);
-        this.userIDList[0]["userID"] = event.target.value;
+        this.userIDList[index]["userID"] = event.target.value;
       }
     },
-
-    async processForm() {
-      var authType = "SRN";
-      //parsing the userID from user input
-      const userID = parseInt(this.userIDList["0"]["userID"]);
-
+    //method that authentiates the SRN
+    async authenticateSRN(userID) {
       //invokes the validation function
-      let userIsValidated = validateSRN(
+      let userIsValidated = await validateSRN(
         userID,
         this.validateCount,
         this.isSingleEntryOnly,
@@ -130,36 +165,54 @@ export default {
         this.purposeParams,
         this.redirectTo
       );
-
-      userIsValidated.then((result) => {
-        this.isUserValid = result.isUserValid;
-        this.validateCount = result.validateCount;
-        this.invalidLoginMessage = result.invalidLoginMessage;
-
-        // either the user is valid or the user has been checked twice
-        if (this.isUserValid || this.validateCount > 1) {
-          if (
-            redirectToDestination(
-              this.purposeParams,
-              userID,
-              this.redirectID,
-              this.redirectTo,
-              this.isUserValid,
-              authType
-            )
-          ) {
-            sendSQSMessage(
-              this.purpose,
-              this.purposeParams,
-              this.redirectTo,
-              this.redirectID,
-              userID,
-              this.isUserValid,
-              authType
-            );
-          }
+      this.isUserValid = userIsValidated.isUserValid;
+      this.validateCount = userIsValidated.validateCount;
+      this.invalidLoginMessage = userIsValidated.invalidLoginMessage;
+    },
+    //method called after clicking the submit button
+    async processForm() {
+      var authType = "SRN";
+      //if only one SRN is entered
+      if (this.userIDList.length == 1) {
+        //parsing the userID from user input
+        let userID = parseInt(this.userIDList["0"]["userID"]);
+        //invokes the validation function
+        await this.authenticateSRN(userID);
+        //sets the valid flag for that SRN
+        this.userIDList[0]["valid"] = this.isUserValid;
+      } else {
+        //all previously typed SRN's will be authenticated through the addField method.
+        // The last SRN will be authenticated after Submit button is clicked
+        let last = this.userIDList.slice(-1);
+        let userID = parseInt(last[0]["userID"]);
+        if (!isNaN(userID)) {
+          await this.authenticateSRN(userID);
+          last[0]["valid"] = this.isUserValid;
         }
-      });
+      }
+      // either the user is valid or the user has been checked twice
+      if (this.isUserValid || this.validateCount > 1) {
+        if (
+          redirectToDestination(
+            this.purposeParams,
+            this.userIDList,
+            this.redirectID,
+            this.redirectTo,
+            this.isUserValid,
+            authType
+          )
+        ) {
+          sendSQSMessage(
+            this.purpose,
+            this.purposeParams,
+            this.redirectTo,
+            this.redirectID,
+            this.userIDList,
+            this.isUserValid,
+            authType
+          );
+        }
+      }
     },
   },
 };
@@ -178,19 +231,15 @@ label {
 .buttonStyleClass {
   @apply bg-primary hover:bg-primary-hover text-white uppercase text-lg mx-auto p-4 mt-4 rounded disabled:opacity-50;
 }
-
+.addButtonStyleClass {
+  @apply bg-white flex flex-row mx-auto p-2;
+}
 .errorStyleClass {
   @apply mx-auto text-red-700 text-base mb-1;
 }
-
-.multiple-div {
-  @apply flex items-center;
-}
-
 .multipleStudentStyle {
-  @apply relative flex flex-row w-1/4 mx-auto;
+  @apply flex flex-row w-1/2 md:w-1/6 lg:w-1/6  mx-auto;
 }
-
 .plus-sign {
   margin: auto;
   border: 1px solid;
@@ -238,7 +287,7 @@ label {
   top: 50%;
   width: 15px;
   margin-left: -8px;
-  margin-top: -3px;
+  margin-top: -2px;
   border-top: 4px solid;
 }
 </style>

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -198,7 +198,6 @@ export default {
             this.userIDList,
             this.redirectID,
             this.redirectTo,
-            this.isUserValid,
             authType
           )
         ) {
@@ -208,7 +207,6 @@ export default {
             this.redirectTo,
             this.redirectID,
             this.userIDList,
-            this.isUserValid,
             authType
           );
         }

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -165,9 +165,9 @@ export default {
         this.purposeParams,
         this.redirectTo
       );
-      this.isUserValid = userIsValidated.isUserValid;
-      this.validateCount = userIsValidated.validateCount;
-      this.invalidLoginMessage = userIsValidated.invalidLoginMessage;
+      this.isUserValid = userValidationResponse.isUserValid;
+      this.validateCount = userValidationResponse.validateCount;
+      this.invalidLoginMessage = userValidationResponse.invalidLoginMessage;
     },
     //method called after clicking the submit button
     async processForm() {

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -14,7 +14,7 @@ export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirec
 
     const messageBody = [
       {
-        dateTime: new Date(),
+        dateTime: Date.parse(new Date()),
         purpose: {
           type: purpose,
           subType: purposeParams,

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -14,7 +14,7 @@ export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirec
 
     const messageBody = [
       {
-        dateTime: Date.now(),
+        dateTime: new Date(),
         purpose: {
           type: purpose,
           subType: purposeParams,

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -5,12 +5,12 @@ const QUEUEURL = "https://sqs.ap-south-1.amazonaws.com/111766607077/EventQueue";
 const sqsClient = new SQSClient({
   region: REGION,
   credentials: {
-    accessKeyId: process.env.VUE_APP_AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.VUE_APP_AWS_SECRET_KEY,
+    accessKeyId: process.env.VUE_APP_AWS_SQS_ACCESS_KEY,
+    secretAccessKey: process.env.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY,
   },
 });
 
-export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirectID, userID, isUserValid, authType) {
+export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirectID, userIDList, authType) {
 
     const messageBody = [
       {
@@ -25,8 +25,7 @@ export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirec
         },
         authType: authType,
         user: {
-          values: userID,
-          userDataValidated: isUserValid,
+          values: userIDList,
         },
       },
     ];

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -5,8 +5,8 @@ const QUEUEURL = "https://sqs.ap-south-1.amazonaws.com/111766607077/EventQueue";
 const sqsClient = new SQSClient({
   region: REGION,
   credentials: {
-    accessKeyId: process.env.VUE_APP_AWS_SQS_ACCESS_KEY,
-    secretAccessKey: process.env.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY,
+    accessKeyId: process.env.VUE_APP_AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.VUE_APP_AWS_SECRET_KEY,
   },
 });
 

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -14,7 +14,7 @@ export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirec
 
     const messageBody = [
       {
-        dateTime: Date.parse(new Date()),
+        dateTime: Date.now(),
         purpose: {
           type: purpose,
           subType: purposeParams,

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,7 +1,7 @@
 import { sendSQSMessage } from "@/services/API/sqs";
 //expects purposeParams, based on the value redirects to respective destination
 
-export function redirectToDestination(purposeParams, userIDList, redirectID, redirectTo, isUserValid, authType){
+export function redirectToDestination(purposeParams, userIDList, redirectID, redirectTo, authType){
     var redirectURL = "";
     var fullurl = "";
     
@@ -35,7 +35,6 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
                 redirectTo,
                 redirectID,
                 userIDList,
-                isUserValid,
                 authType
               );
             return false

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,12 +1,13 @@
 import { sendSQSMessage } from "@/services/API/sqs";
 //expects purposeParams, based on the value redirects to respective destination
 
-export function redirectToDestination(purposeParams, userID, redirectID, redirectTo, isUserValid, authType){
+export function redirectToDestination(purposeParams, userIDList, redirectID, redirectTo, isUserValid, authType){
     var redirectURL = "";
     var fullurl = "";
-
+    
     switch(purposeParams){
-        case 'plio':
+        case 'plio':    
+            var userID = userIDList[0]["userID"]
             //constructs the URL based on the redirectTo param
             redirectURL = process.env.VUE_APP_BASE_URL_PLIO;
             var url = new URL(redirectURL + redirectID); //adds plioID to the base plio link
@@ -20,6 +21,7 @@ export function redirectToDestination(purposeParams, userID, redirectID, redirec
 
         case 'liveclass':
             //constructs the URL based on the redirectTo param
+            
             redirectURL = process.env.VUE_APP_BASE_URL_MEET;
             fullurl = new URL(redirectURL + redirectID); //adds meetID to the base plio link
             break;
@@ -32,7 +34,7 @@ export function redirectToDestination(purposeParams, userID, redirectID, redirec
                 purposeParams,
                 redirectTo,
                 redirectID,
-                userID,
+                userIDList,
                 isUserValid,
                 authType
               );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,12 @@ module.exports = {
   purge: ["./public/index.html", "./src/**/*.{vue,js,ts,jsx,tsx}"],
   darkMode: false, // or 'media' or 'class'
   theme: {
+    screens: {
+      'sm': '640px',
+      'md': '768px',
+      'lg': '1024px',
+      'xl': '1280px',
+    },
     extend: {
       colors: {
         primary: "#F78000",

--- a/vue.config.js
+++ b/vue.config.js
@@ -2,7 +2,6 @@ module.exports = {
   transpileDependencies: [
     /@vue\/*/,
     'vue-router',
-    'plyr',
     '@aws-sdk',
   ],
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  transpileDependencies: [
+    /@vue\/*/,
+    'vue-router',
+    'plyr',
+    '@aws-sdk',
+  ],
+}


### PR DESCRIPTION
- Added support to have more than one SRN entry. 
- Split the process method `processForm` into `authenticateSRN` and `processForm`.
- Also, made the change to the input array. The `userIDList` also contains a boolean variable for each SRN which tells whether the SRN is valid or not. This helps to create separate rows in Bigquery for each SRN. 
- Have removed the userDataValidated flag in SQS message as the userIDList array itself contains the userID and the respective valid flag.

Example of the SQS message: `{'dateTime': '2021-10-06T10:17:51.887Z', 'purpose': {'type': 'attendance', 'subType': 'liveclass', 'params': {'platform': 'meet', 'id': 'eig-ioxa-rvj'}}, 'authType': 'SRN', 'user': {'values': [{'userID': '1111111111', 'valid': True}, {'userID': '1231231231', 'valid': False}, {'userID': '1111111110', 'valid': True}]}}`