### PR TITLE
Transpiling

### DIFF
--- a/.github/workflows/deploy_to_s3_staging.yml
+++ b/.github/workflows/deploy_to_s3_staging.yml
@@ -41,7 +41,7 @@ jobs:
         VUE_APP_AWS_SECRET_KEY: ${{ secrets.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY }}
         VUE_APP_BASE_URL_MEET: 'https://meet.google.com/'
 
-      run: npm run build --mode staging
+      run: npm run build
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy_to_s3_staging.yml
+++ b/.github/workflows/deploy_to_s3_staging.yml
@@ -34,14 +34,14 @@ jobs:
     # build the vuepress docs
     - name: Build
       env:
-        NODE_ENV: staging
+        NODE_ENV: production
         VUE_APP_AF_API_KEY: ${{ secrets.VUE_APP_AF_API_KEY }}
         VUE_APP_BASE_URL_PLIO: 'https://staging-app.plio.in/#/af/play/'
         VUE_APP_AWS_ACCESS_KEY_ID: ${{ secrets.VUE_APP_AWS_SQS_ACCESS_KEY }}
         VUE_APP_AWS_SECRET_KEY: ${{ secrets.VUE_APP_AWS_SQS_SECRET_ACCESS_KEY }}
         VUE_APP_BASE_URL_MEET: 'https://meet.google.com/'
 
-      run: npm run build
+      run: npm run build --mode staging
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  transpileDependencies: [
+    /@vue\/*/,
+    'vue-router',
+    'plyr',
+    '@aws-sdk',
+  ],
+}


### PR DESCRIPTION
What was the issue?
- Some packages used by us (for example - some @vue3 packages, vue-router, plyr, @aws-sdk) are written with some ES6 syntax. 
- That might include, let's say, arrow functions (`=>`)
- Browsers like Vivo browser, Oppo browser are based upon old webview engines, which doesn't identify ES6 syntax and hence throws a syntax error.
- Because of that syntax error, the website froze and never actually loaded up.

Solution?
- Use Babel to do the heavy lifting. Babel is a tool which converts ES6 syntax code into backwards compatible version of JavaScript in current and older browsers or environments.
- As our project was set up using vue CLI, we'll use a babel plugin that's specifically created for vue cli [here](https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-babel#readme). It's already installed as one of our packages
- The plugin, by default, converts all the application code into backwards-compatible code but skips the `node_modules/` folder. But that is where our packages reside which are using the ES6 syntax.
- We have to manually specify which packages we need Babel to transpile. More details [here](https://github.com/vuejs/vue-cli/tree/dev/packages/@vue/cli-plugin-babel#configuration)
