### PR TITLE
Capturing incorrect SRN entries

### DIFF
--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -129,7 +129,7 @@ export default {
     ifUserEnteredMoreThanOne() {
       return !this.isSingleEntryOnly && this.userIdListLength > 1;
     },
-    //for now, plio does not support multiple input entries
+    /** for now, plio does not support multiple input entries */
     isSingleEntryOnly() {
       return this.redirectTo == "plio";
     },

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -133,10 +133,13 @@ export default {
     isSingleEntryOnly() {
       return this.redirectTo == "plio";
     },
-    /* returns submit button as disabled if any of the following is true:
-     - no SRN has been typed
-     - input is invalid
-     - SRN hasn't been completely typed */
+    /**
+      * whether the submit button is disabled
+      * true if any of the following conditions are met:
+      * - no SRN has been typed
+      * - input is invalid
+      * - SRN hasn't been completely typed
+      */
     isSubmitButtonDisabled() {
       return (
         !this.isAnyUserIDPresent ||

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -254,14 +254,16 @@ export default {
         this.getLatestEntry["userID"] = "";
       }
 
+      //incorrect entry the first time
       if(!this.isUserValid && this.validateCount == 1){
         var purposeParams = "incorrect-entry"
+        var tempUserIDList = [{userID: userID.toString(), valid: this.isUserValid}]
         sendSQSMessage(
             this.purpose,
             purposeParams,
             this.redirectTo,
             this.redirectID,
-            this.userIDList,
+            tempUserIDList,
             authType
           );
       }

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -54,7 +54,7 @@
     }}</span>
     <span
       class="mx-auto text-red-700 text-base mb-1"
-      v-if="!isUserValid && validateCount == 1"
+      v-if="!isCurrentUserValid && validateCount == 1"
       >{{ invalidLoginMessage }}</span
     >
     <!-- add srn button -->
@@ -105,7 +105,7 @@ export default {
     return {
       userIDList: [{ userID: "", valid: false }], //array containing user-id's and a valid flag for each
       invalidInputMessage: null, //flag to check if the input is in correct format
-      isUserValid: false, // whether the user exists in the backend database
+      isCurrentUserValid: false, // temp flag 
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
       invalidLoginMessage: "Please enter correct SRN / कृपया सही SRN दर्ज करें",
@@ -113,48 +113,63 @@ export default {
     };
   },
   computed: {
+    //returns length of the userID list
     userIdListLength() {
       return this.userIDList.length;
     },
+    //checks if any userID has been typed
     isAnyUserIDPresent() {
-      //checks if any userID has been typed
       return (
         this.userIDList != undefined &&
         this.userIdListLength > 0 &&
         this.userIDList[0]["userID"] != ""
       );
     },
+    //checks if multiple entries are allowed and if one entry is already inputted
     ifUserEnteredMoreThanOne() {
-      //used when multiple SRN's will be allowed to typed
       return !this.isSingleEntryOnly && this.userIdListLength > 1;
     },
+    //for now, plio does not support multiple input entries
     isSingleEntryOnly() {
       return this.redirectTo == "plio";
     },
+    /* returns submit button as disabled if any of the following is true:
+     - no SRN has been typed
+     - input is invalid
+     - SRN hasn't been completely typed */
     isSubmitButtonDisabled() {
-      //submit button is disabled if no SRN has been typed or input is invalid or SRN hasn't been completely typed
       return (
         !this.isAnyUserIDPresent ||
         this.invalidInputMessage != "" ||
         this.isCurrentEntryIncomplete
       );
     },
+    /* checks if + button should be displayed. Will be activated only if:
+     - multiple entries are allowed
+     - if current input entry is complete
+     - if cap of maximum entries hasn't been reached yet */
     isAddButtonAllowed() {
-      //if multiple SRN's are allowed, then this helps with the activation of the + button, to add more SRN's
       return (
         !this.isSingleEntryOnly &&
         !this.isCurrentEntryIncomplete &&
         this.userIdListLength < numberOfSRNsAllowed
       );
     },
+    // checks if the current input entry has the required number of characters.
     isCurrentEntryIncomplete() {
       return this.getLatestEntry["userID"].length < this.maxLengthOfSRN;
     },
+    // returns the most recent typed input entry
     getLatestEntry() {
       return this.userIDList.slice(-1)[0];
     },
   },
   methods: {
+    /* determines how the input box should look like depending on which box it is. 
+      - if the input box is the current one (i.e. being typed) and if the input is invalid (invalid input message is being displayed),
+        then, the box has a border of red
+      - if the input box is a past one (i.e. already typed), then the box is shown as unclickable 
+      @param {Number} - index - index of the input box */
     calculateInputboxStyleClasses(index) {
       return [
         {
@@ -164,64 +179,87 @@ export default {
         },
       ];
     },
+    /* checks to see if the input character is a number. Makes use of ASCII values.
+    @param {Event} - e - event triggered when a character is typed.  */
     isValidNumericEntry(e) {
-      //checking to see if each char typed by user is only a number
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();
     },
+    // adds a new dict to the array - userIDList
     addNewEmptyField() {
       this.userIDList.push({ userID: "", valid: false });
     },
+    /* removes an element in the array at a given index. 
+    @param {Number} - index - the index of the input box where - button is clicked. */
     removeInputField(index) {
       this.userIDList.splice(index, 1);
     },
+    // sets the invalid input message to null (default)
     resetInvalidInputMessage() {
       this.invalidInputMessage = "";
     },
+    // sets the invalid login message to null (default)
     resetInvalidLoginMessage() {
       this.invalidLoginMessage = "";
     },
+    // sets the temp valid flag to false (default) for authentication of a possible next user
     resetValidFlag() {
-      this.isUserValid = false;
+      this.isCurrentUserValid = false;
     },
+    // sets the valid key of the latest user to the value of the temp flag. The temp flag contains the value returned by the backend
     setValidFlag() {
-      this.getLatestEntry["valid"] = this.isUserValid;
+      this.getLatestEntry["valid"] = this.isCurrentUserValid;
     },
-    //resets input field at an index
+    //resets the userID key of an element in the array at a particular index.
     resetEntry(index){
         this.userIDList[index]["userID"] = "";
     },
+    /* this function is called whenever the + button is clicked. The most recent typed entry is authenticated against the database. 
+    - if it does not exist and it is the first time being authenticated, handleIncorrectEntry() is called. 
+    - if the entry exists or if it is being authenticated the second time, the 'valid' flag of the entry is set to whatever the value is returned by the backend. 
+      Also, isCurrentUserValid and validateCount are reset to their default values, so that a possible next entry can be processed. */
     async addField() {
-      //for adding another field, the previously entered ID is validated against the database
       const latestUserID = parseInt(this.getLatestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
-        if(!this.isUserValid && this.validateCount == 1){
+        if(!this.isCurrentUserValid && this.validateCount == 1){
           this.handleIncorrectEntry(latestUserID);
         }
-        //only if the SRN is valid or if the user is entering a SRN for the second time,the loop is entered
-        if (this.isUserValid || this.validateCount > 1) {
-          //setting the flag of the SRN
+        if (this.isCurrentUserValid || this.validateCount > 1) {
           this.setValidFlag();
           this.addNewEmptyField();
-          //resetting flags to default for processing next SRN
           this.resetValidFlag;
           this.validateCount = 0;
         }
       }
     },
+    /* Before an element is removed from the userIDList array, the login message and input message are reset to default values. 
+       removeInputField() is called to remove the element. 
+       In most cases, this would be enough. But there is one edge case:
+      Let's say the user typed in ID 'A' and decides to add another entry. This means 'A' is authenticated and it is valid/invalid. 
+      The user types in the ID 'B' as the next entry and it is invalid. 
+      The user changed their mind and decided to delete this entry ('B'). At this point, the variables will be in the following state:
+        validateCount = 1
+        isCurrentUserValid = false
+      The state of the variables contradict the fact that 'A' is already authenticated. This means any of the two cases:
+      - A is valid, so validateCount = 0 and isCurrentUserValid = true
+      - A is invalid, so validateCount = 2 and isCurrentUserValid = false
+      So when the user clicks submit, 'A' is authenticated again, which is a behaviour we do not want. So to bypass this, validateCount is set to 2. 
+      (To better understand how this will help, understanding processForm() will help.) 
+      isCurrentUserValid flag is ignored because the value is already set in each user's valid flag. 
+      @params {Number} - index - index of input field to be removed */
     removeField(index) {
-      //resetting all messages to default before deleting the input field
       this.resetInvalidInputMessage;
       this.resetInvalidLoginMessage;
-      //edge case: user enters an invalid SRN. Error message is displayed. The user is given another chance. User adds another input field but decided to remove it.
-      // At this point, the variables are reset. So the previously entered SRN is checked again, which should not happen. so setting this validateCount = 2 will bypass this.
-      //Will not affect any other case. The user can either submit or decide to add another field again.
       this.validateCount = 2;
       this.removeInputField(index);
     },
+    /*  this function is called whenever something is entered in the input box. It checks if the required number of characters are being typed. 
+    Until then, it prompts the user to type the required characters. 
+    If the user types more than the desired number of characters, the input is sliced and the user wont be able to see the extra characters.
+    @params {Event} - event - the event which triggered this function
+    @params {Number} - index - the index of the input field */
     updateValue(event, index) {
-      //checks if the 10 characters are entered
       if (event.target.value.length == 0) {
         this.invalidInputMessage = "";
       } else if (event.target.value.length < this.maxLengthOfSRN) {
@@ -230,17 +268,22 @@ export default {
       } else {
         this.resetInvalidInputMessage();
       }
-      //if more than 10 characters are entered, slicing the input to only 10
-      // index tells us which input field is being considered
       if (event.target.value.length > this.maxLengthOfSRN) {
         event.target.value = event.target.value.slice(0, this.maxLengthOfSRN);
         this.userIDList[index]["userID"] = event.target.value.toString();
       }
     },
-    //incorrect entry the first time
+    /* this functions handle all invalid/incorrect entries. An SQS message is sent with the following parameters:
+    - purpose - from URL
+    - purposeParams - "incorrect-entry"
+    - redirectTo - from URL
+    - redirectID - from URL
+    - tempUserIDList - which contains only the ID of the incorrect entry
+    - authType - from URL 
+    @params {String} - userID - ID of the incorrect entry field */
     handleIncorrectEntry(userID){
         var purposeParams = "incorrect-entry"
-        var tempUserIDList = [{userID: userID.toString(), valid: this.isUserValid}]
+        var tempUserIDList = [{userID: userID.toString(), valid: this.isCurrentUserValid}]
         sendSQSMessage(
             this.purpose,
             purposeParams,
@@ -250,50 +293,45 @@ export default {
             authType
           );
     },
-    //method that authentiates the SRN
+    /* this method is called whenever + button is clicked. It authenticates the most recent typed ID. 
+    If the ID is invalid, then the login mesasge displays an error and the input field is cleared for the user to correct their entry.
+    @params {String} - userID - most recent ID  */
     async authenticateSRN(userID) {
       this.isLoading = true;
-      //invokes the validation function
       let userValidationResponse = await validateSRN(
         userID,
         this.validateCount,
         this.isSingleEntryOnly,
         this.redirectID,
-        this.isUserValid,
+        this.isCurrentUserValid,
         this.purpose,
         this.purposeParams,
         this.redirectTo
       );
-      this.isUserValid = userValidationResponse.isUserValid;
+      this.isCurrentUserValid = userValidationResponse.isCurrentUserValid;
       this.validateCount = userValidationResponse.validateCount;
       this.invalidLoginMessage = userValidationResponse.invalidLoginMessage;
       this.isLoading = false;
-      //clear the input field if entry is incorrect
+
       if(this.invalidLoginMessage != ""){
         this.resetEntry(this.userIdListLength - 1)
       }
-      
-
-      
     },
-    //method called after clicking the submit button
+    /* this method is called after the user clicks the submit button. Since all the ID's but the last are authenticated, this method calls authenticateSRN(). 
+    If the user is invalid and is being authenticated the first time, handleIncorrectEntry() is called. 
+    If the user is valid or is being authenticated the second time, the user is reidrected to their destination and an SQS message is sent. */
     async processForm() {
-   
-
-      //all previously typed SRN's will be authenticated through the addField method.
-      // The last SRN will be authenticated after Submit button is clicked
-      // (will work even for single entry as the first entry can be also considered as the last entry)
       let latestUserID = parseInt(this.getLatestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
-        if(!this.isUserValid && this.validateCount == 1){
+        if(!this.isCurrentUserValid && this.validateCount == 1){
         this.handleIncorrectEntry(latestUserID);
         }
         this.setValidFlag();
       }
 
       // either the user is valid or the user has been checked twice
-      if (this.isUserValid || this.validateCount > 1) {
+      if (this.isCurrentUserValid || this.validateCount > 1) {
         if (
           redirectToDestination(
             this.purposeParams,

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -113,7 +113,7 @@ export default {
     };
   },
   computed: {
-    //returns length of the userID list
+    /** returns length of the list of user IDs */
     userIdListLength() {
       return this.userIDList.length;
     },

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -105,7 +105,7 @@ export default {
     return {
       userIDList: [{ userID: "", valid: false }], //array containing user-id's and a valid flag for each
       invalidInputMessage: null, //flag to check if the input is in correct format
-      isCurrentUserValid: false, // temp flag which contains the validity of the most recent user ID
+      isCurrentUserValid: false, // whether the current user is valid
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
       invalidLoginMessage: "Please enter correct SRN / कृपया सही SRN दर्ज करें",

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -162,8 +162,8 @@ export default {
     isCurrentEntryIncomplete() {
       return this.getLatestEntry["userID"].length < this.maxLengthOfSRN;
     },
-    // returns the most recent typed input entry
-    getLatestEntry() {
+    // returns the most recently entered input
+    latestEntry() {
       return this.userIDList.slice(-1)[0];
     },
   },

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -91,6 +91,7 @@ import { redirectToDestination } from "@/services/redirectToDestination.js";
 import { sendSQSMessage } from "@/services/API/sqs";
 
 const numberOfSRNsAllowed = 10;
+const authType = "SRN";
 
 export default {
   name: "SRNEntry",
@@ -247,10 +248,27 @@ export default {
       this.validateCount = userValidationResponse.validateCount;
       this.invalidLoginMessage = userValidationResponse.invalidLoginMessage;
       this.isLoading = false;
+
+      //clear the input field if entry is incorrect
+      if(this.invalidLoginMessage != ""){
+        this.getLatestEntry["userID"] = "";
+      }
+
+      if(!this.isUserValid && this.validateCount == 1){
+        var purposeParams = "incorrect-entry"
+        sendSQSMessage(
+            this.purpose,
+            purposeParams,
+            this.redirectTo,
+            this.redirectID,
+            this.userIDList,
+            authType
+          );
+      }
     },
     //method called after clicking the submit button
     async processForm() {
-      var authType = "SRN";
+   
 
       //all previously typed SRN's will be authenticated through the addField method.
       // The last SRN will be authenticated after Submit button is clicked

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -260,7 +260,7 @@ export default {
     /*  this function is called whenever something is entered in the input box. It checks if the required number of characters are being typed. 
     Until then, it prompts the user to type the required characters. 
     If the user types more than the desired number of characters, the input is sliced and the user wont be able to see the extra characters.
-    @params {Event} - event - the event which triggered this function
+    @param {Object} - event - the event which triggered this function
     @params {Number} - index - the index of the input field */
     updateValue(event, index) {
       if (event.target.value.length == 0) {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -104,7 +104,7 @@ export default {
   data() {
     return {
       userIDList: [{ userID: "", valid: false }], //array containing user-id's and a valid flag for each
-      invalidInputMessage: null, //flag to check if the input is in correct format
+      invalidInputMessage: null, // whether the input is in correct format
       isCurrentUserValid: false, // whether the current user is valid
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -105,11 +105,11 @@ export default {
     return {
       userIDList: [{ userID: "", valid: false }], //array containing user-id's and a valid flag for each
       invalidInputMessage: null, //flag to check if the input is in correct format
-      isCurrentUserValid: false, // temp flag 
+      isCurrentUserValid: false, // temp flag which contains the validity of the most recent user ID
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
       invalidLoginMessage: "Please enter correct SRN / कृपया सही SRN दर्ज करें",
-      isLoading: false,
+      isLoading: false, 
     };
   },
   computed: {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -133,7 +133,7 @@ export default {
     },
     /**
      * Whether the submit button is disabled
-     * true if any of the following conditions are met:
+     * Returns true if any of the following conditions are met:
      * - no SRN has been typed
      * - input is invalid
      * - SRN hasn't been completely typed
@@ -168,7 +168,7 @@ export default {
     },
   },
   methods: {
-    /** Determines how the input box should look like depending on which input field it is.
+    /** Determines how the input box should look.
      * @param {Number} index - index of the input box
      */
     calculateInputboxStyleClasses(index) {
@@ -187,21 +187,21 @@ export default {
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();
     },
-    /** Adds a new dict to the array - userIDList */
+    /** Adds a new object to the userIDList array */
     addNewEmptyField() {
       this.userIDList.push({ userID: "", valid: false });
     },
     /** Removes an element in the array at a given index.
-     * @param {Number} index - the index of the input box where - button is clicked
+     * @param {Number} index - the index of the input box where "-" button is clicked
      */
     removeInputField(index) {
       this.userIDList.splice(index, 1);
     },
-    /** Sets the invalid input message to null (default) */
+    /** Resets the invalid input message */
     resetInvalidInputMessage() {
       this.invalidInputMessage = "";
     },
-    /** Sets the invalid login message to null (default) */
+    /** Resets the invalid login message */
     resetInvalidLoginMessage() {
       this.invalidLoginMessage = "";
     },
@@ -247,7 +247,7 @@ export default {
 
     /** This function is called whenever something is entered in the input box.
      * It checks if the required number of characters are being typed.
-     * @param {Event} event - the event which triggered this function
+     * @param {Object} event - the event which triggered this function
      * @param {Number} index - the index of the input field
      */
     updateValue(event, index) {
@@ -298,8 +298,7 @@ export default {
       }
     },
 
-    /** This method is called after the user clicks the submit button.
-     */
+    /** This method is called after the user clicks the submit button.*/
     async processForm() {
       let latestUserID = parseInt(this.latestEntry["userID"]);
       if (!isNaN(latestUserID)) {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -127,7 +127,8 @@ export default {
     ifUserEnteredMoreThanOne() {
       return !this.isSingleEntryOnly && this.userIdListLength > 1;
     },
-    /** For now, plio does not support multiple input entries */
+    /** Whether only a single entry is allowed.
+     * For now, plio does not support multiple input entries */
     isSingleEntryOnly() {
       return this.redirectTo == "plio";
     },
@@ -217,8 +218,8 @@ export default {
     resetEntry(index) {
       this.userIDList[index]["userID"] = "";
     },
-    /** This function is called whenever the + button is clicked.
-     * The most recent typed entry is authenticated against the database.
+    /** This function is called whenever the "+"" button is clicked.
+     * Authenticates the most recent typed entry against the database.
      */
     async addField() {
       const latestUserID = parseInt(this.latestEntry["userID"]);
@@ -235,7 +236,8 @@ export default {
         }
       }
     },
-    /** This method is called whenever - button is clicked, to remove an input field
+    /** This method is called whenever - button is clicked.
+     * Removes the selected entry from the entry list and resets appropriate variables
      * @param {Number} index - index of input field to be removed
      */
     removeField(index) {
@@ -298,7 +300,8 @@ export default {
       }
     },
 
-    /** This method is called after the user clicks the submit button.
+    /** Authenticates the last entry typed before the submit button is clicked.
+     * Also, redirects user to the destination and sends a SQS message.
      */
     async processForm() {
       let latestUserID = parseInt(this.latestEntry["userID"]);

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -111,11 +111,11 @@ export default {
     };
   },
   computed: {
-    /** returns length of the list of user IDs */
+    /** Returns length of the list of user IDs */
     userIdListLength() {
       return this.userIDList.length;
     },
-    /** checks if any userID has been entered */
+    /** Checks if any userID has been entered */
     isAnyUserIDPresent() {
       return (
         this.userIDList != undefined &&
@@ -123,16 +123,16 @@ export default {
         this.userIDList[0]["userID"] != ""
       );
     },
-    /** whether multiple entries have been made by the user */
+    /** Whether multiple entries have been made by the user */
     ifUserEnteredMoreThanOne() {
       return !this.isSingleEntryOnly && this.userIdListLength > 1;
     },
-    /** for now, plio does not support multiple input entries */
+    /** For now, plio does not support multiple input entries */
     isSingleEntryOnly() {
       return this.redirectTo == "plio";
     },
     /**
-     * whether the submit button is disabled
+     * Whether the submit button is disabled
      * true if any of the following conditions are met:
      * - no SRN has been typed
      * - input is invalid
@@ -146,7 +146,7 @@ export default {
       );
     },
     /**
-     * checks if + button should be displayed. Will be activated only if:
+     * Checks if + button should be displayed. Will be activated only if:
      * - multiple entries are allowed
      * - if current input entry is complete
      * - if cap of maximum entries hasn't been reached yet
@@ -158,21 +158,19 @@ export default {
         this.userIdListLength < numberOfSRNsAllowed
       );
     },
-    /** checks if the current input entry has the required number of characters */
+    /** Checks if the current input entry has the required number of characters */
     isCurrentEntryIncomplete() {
-      return this.getLatestEntry["userID"].length < this.maxLengthOfSRN;
+      return this.latestEntry["userID"].length < this.maxLengthOfSRN;
     },
-    // returns the most recently entered input
+    /** Returns the most recently entered input */
     latestEntry() {
       return this.userIDList.slice(-1)[0];
     },
   },
   methods: {
-    /* determines how the input box should look like depending on which box it is.
-      - if the input box is the current one (i.e. being typed) and if the input is invalid (invalid input message is being displayed),
-        then, the box has a border of red
-      - if the input box is a past one (i.e. already typed), then the box is shown as unclickable
-      @param {Number} - index - index of the input box */
+    /** Determines how the input box should look like depending on which input field it is.
+     * @param {Number} index - index of the input box
+     */
     calculateInputboxStyleClasses(index) {
       return [
         {
@@ -182,38 +180,40 @@ export default {
         },
       ];
     },
-    /* checks to see if the input character is a number. Makes use of ASCII values.
-    @param {Object} - e - event triggered when a character is typed.  */
+    /** Checks to see if the input character is a number. Makes use of ASCII values.
+     * @param {Object} e - event triggered when a character is typed
+     */
     isValidNumericEntry(e) {
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();
     },
-    // adds a new dict to the array - userIDList
+    /** Adds a new dict to the array - userIDList */
     addNewEmptyField() {
       this.userIDList.push({ userID: "", valid: false });
     },
-    /* removes an element in the array at a given index.
-    @param {Number} - index - the index of the input box where - button is clicked. */
+    /** Removes an element in the array at a given index.
+     * @param {Number} index - the index of the input box where - button is clicked
+     */
     removeInputField(index) {
       this.userIDList.splice(index, 1);
     },
-    // sets the invalid input message to null (default)
+    /** Sets the invalid input message to null (default) */
     resetInvalidInputMessage() {
       this.invalidInputMessage = "";
     },
-    // sets the invalid login message to null (default)
+    /** Sets the invalid login message to null (default) */
     resetInvalidLoginMessage() {
       this.invalidLoginMessage = "";
     },
-    // sets the temp valid flag to false (default) for authentication of a possible next user
+    /** Sets the temp valid flag to false (default) for authentication of a possible next user */
     resetValidFlag() {
       this.isCurrentUserValid = false;
     },
-    // sets the valid key of the latest user to the value of the temp flag. The temp flag contains the value returned by the backend
+    /** Sets the valid key of the latest user to the value of the temp flag. The temp flag contains the value returned by the backend */
     setValidFlag() {
-      this.getLatestEntry["valid"] = this.isCurrentUserValid;
+      this.latestEntry["valid"] = this.isCurrentUserValid;
     },
-    //resets the userID key of an element in the array at a particular index.
+    /** Resets the userID key of an element in the array at a particular index */
     resetEntry(index) {
       this.userIDList[index]["userID"] = "";
     },
@@ -221,7 +221,7 @@ export default {
      * The most recent typed entry is authenticated against the database.
      */
     async addField() {
-      const latestUserID = parseInt(this.getLatestEntry["userID"]);
+      const latestUserID = parseInt(this.latestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
         if (!this.isCurrentUserValid && this.validateCount == 1) {
@@ -301,7 +301,7 @@ export default {
     /** This method is called after the user clicks the submit button.
      */
     async processForm() {
-      let latestUserID = parseInt(this.getLatestEntry["userID"]);
+      let latestUserID = parseInt(this.latestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
         if (!this.isCurrentUserValid && this.validateCount == 1) {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -52,11 +52,9 @@
     <span class="mx-auto text-red-700 text-base mb-1" v-if="invalidInputMessage">{{
       invalidInputMessage
     }}</span>
-    <span
-      class="mx-auto text-red-700 text-base mb-1"
-      v-if="isInvalidLoginMessageShown"
-      >{{ invalidLoginMessage }}</span
-    >
+    <span class="mx-auto text-red-700 text-base mb-1" v-if="isInvalidLoginMessageShown">{{
+      invalidLoginMessage
+    }}</span>
     <!-- add srn button -->
     <div class="my-auto" v-if="isAddButtonAllowed">
       <button
@@ -109,7 +107,7 @@ export default {
       maxLengthOfSRN: 10,
       validateCount: 0, //this variable tells us how many times the user has been validated.
       invalidLoginMessage: "Please enter correct SRN / कृपया सही SRN दर्ज करें",
-      isLoading: false, 
+      isLoading: false,
     };
   },
   computed: {
@@ -147,11 +145,11 @@ export default {
         this.isCurrentEntryIncomplete
       );
     },
-    /** 
+    /**
      * checks if + button should be displayed. Will be activated only if:
      * - multiple entries are allowed
      * - if current input entry is complete
-     * - if cap of maximum entries hasn't been reached yet 
+     * - if cap of maximum entries hasn't been reached yet
      */
     isAddButtonAllowed() {
       return (
@@ -170,10 +168,10 @@ export default {
     },
   },
   methods: {
-    /* determines how the input box should look like depending on which box it is. 
+    /* determines how the input box should look like depending on which box it is.
       - if the input box is the current one (i.e. being typed) and if the input is invalid (invalid input message is being displayed),
         then, the box has a border of red
-      - if the input box is a past one (i.e. already typed), then the box is shown as unclickable 
+      - if the input box is a past one (i.e. already typed), then the box is shown as unclickable
       @param {Number} - index - index of the input box */
     calculateInputboxStyleClasses(index) {
       return [
@@ -194,7 +192,7 @@ export default {
     addNewEmptyField() {
       this.userIDList.push({ userID: "", valid: false });
     },
-    /* removes an element in the array at a given index. 
+    /* removes an element in the array at a given index.
     @param {Number} - index - the index of the input box where - button is clicked. */
     removeInputField(index) {
       this.userIDList.splice(index, 1);
@@ -219,8 +217,8 @@ export default {
     resetEntry(index){
         this.userIDList[index]["userID"] = "";
     },
-    /** This function is called whenever the + button is clicked. 
-    * The most recent typed entry is authenticated against the database. 
+    /** This function is called whenever the + button is clicked.
+    * The most recent typed entry is authenticated against the database.
     */
     async addField() {
       const latestUserID = parseInt(this.getLatestEntry["userID"]);
@@ -247,14 +245,14 @@ export default {
       this.removeInputField(index);
     },
 <<<<<<< HEAD
-    /** This function is called whenever something is entered in the input box. 
-    * It checks if the required number of characters are being typed. 
+    /** This function is called whenever something is entered in the input box.
+    * It checks if the required number of characters are being typed.
     * @param {Event} event - the event which triggered this function
     * @param {Number} index - the index of the input field
     */
 =======
-    /*  this function is called whenever something is entered in the input box. It checks if the required number of characters are being typed. 
-    Until then, it prompts the user to type the required characters. 
+    /*  this function is called whenever something is entered in the input box. It checks if the required number of characters are being typed.
+    Until then, it prompts the user to type the required characters.
     If the user types more than the desired number of characters, the input is sliced and the user wont be able to see the extra characters.
     @param {Object} - event - the event which triggered this function
     @params {Number} - index - the index of the input field */
@@ -288,8 +286,8 @@ export default {
             authType
           );
     },
-      
-    /** This method is called whenever + button is clicked. It authenticates the most recent typed ID. 
+
+    /** This method is called whenever + button is clicked. It authenticates the most recent typed ID.
     * @param {String} userID - most recent ID
     */
     async authenticateSRN(userID) {
@@ -297,8 +295,8 @@ export default {
       let userValidationResponse = await validateSRN(
         userID,
         this.validateCount
-        
-       
+
+
       );
       this.isCurrentUserValid = userValidationResponse.isCurrentUserValid;
       this.validateCount = userValidationResponse.validateCount;
@@ -310,7 +308,7 @@ export default {
       }
     },
 
-    /** This method is called after the user clicks the submit button. 
+    /** This method is called after the user clicks the submit button.
     */
     async processForm() {
       let latestUserID = parseInt(this.getLatestEntry["userID"]);

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -196,7 +196,9 @@ export default {
       const latestUserID = parseInt(this.getLatestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
-        this.handleIncorrectEntry(latestUserID);
+        if(!this.isUserValid && this.validateCount == 1){
+          this.handleIncorrectEntry(latestUserID);
+        }
         //only if the SRN is valid or if the user is entering a SRN for the second time,the loop is entered
         if (this.isUserValid || this.validateCount > 1) {
           //setting the flag of the SRN
@@ -235,9 +237,8 @@ export default {
         this.userIDList[index]["userID"] = event.target.value.toString();
       }
     },
+    //incorrect entry the first time
     handleIncorrectEntry(userID){
-      //incorrect entry the first time
-      if(!this.isUserValid && this.validateCount == 1){
         var purposeParams = "incorrect-entry"
         var tempUserIDList = [{userID: userID.toString(), valid: this.isUserValid}]
         sendSQSMessage(
@@ -248,7 +249,6 @@ export default {
             tempUserIDList,
             authType
           );
-      }
     },
     //method that authentiates the SRN
     async authenticateSRN(userID) {
@@ -286,7 +286,9 @@ export default {
       let latestUserID = parseInt(this.getLatestEntry["userID"]);
       if (!isNaN(latestUserID)) {
         await this.authenticateSRN(latestUserID);
+        if(!this.isUserValid && this.validateCount == 1){
         this.handleIncorrectEntry(latestUserID);
+        }
         this.setValidFlag();
       }
 

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -147,7 +147,7 @@ export default {
       );
     },
     /**
-     * Checks if + button should be displayed. Will be activated only if:
+     * Checks if "+" button should be displayed. Will be activated only if:
      * - multiple entries are allowed
      * - if current input entry is complete
      * - if cap of maximum entries hasn't been reached yet
@@ -218,7 +218,7 @@ export default {
     resetEntry(index) {
       this.userIDList[index]["userID"] = "";
     },
-    /** This function is called whenever the "+"" button is clicked.
+    /** This function is called whenever the "+" button is clicked.
      * Authenticates the most recent typed entry against the database.
      */
     async addField() {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -246,19 +246,12 @@ export default {
       this.validateCount = 2;
       this.removeInputField(index);
     },
-<<<<<<< HEAD
+
     /** This function is called whenever something is entered in the input box. 
     * It checks if the required number of characters are being typed. 
     * @param {Event} event - the event which triggered this function
     * @param {Number} index - the index of the input field
     */
-=======
-    /*  this function is called whenever something is entered in the input box. It checks if the required number of characters are being typed. 
-    Until then, it prompts the user to type the required characters. 
-    If the user types more than the desired number of characters, the input is sliced and the user wont be able to see the extra characters.
-    @param {Object} - event - the event which triggered this function
-    @params {Number} - index - the index of the input field */
->>>>>>> 2b97ba371f0057cfd46588c4ee89d5e1d1bdb0e2
     updateValue(event, index) {
       if (event.target.value.length == 0) {
         this.invalidInputMessage = "";

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -231,18 +231,18 @@ export default {
         if (this.isCurrentUserValid || this.validateCount > 1) {
           this.setValidFlag();
           this.addNewEmptyField();
-          this.resetValidFlag;
+          this.resetValidFlag();
           this.validateCount = 0;
         }
       }
     },
-    /** This method is called whenever - button is clicked.
+    /** This method is called whenever "-" button is clicked.
      * Removes the selected entry from the entry list and resets appropriate variables
      * @param {Number} index - index of input field to be removed
      */
     removeField(index) {
-      this.resetInvalidInputMessage;
-      this.resetInvalidLoginMessage;
+      this.resetInvalidInputMessage();
+      this.resetInvalidLoginMessage();
       this.validateCount = 2;
       this.removeInputField(index);
     },
@@ -284,7 +284,7 @@ export default {
       );
     },
 
-    /** This method is called whenever + button is clicked. It authenticates the most recent typed ID.
+    /** This method is called whenever "+" button is clicked. It authenticates the most recent typed ID.
      * @param {String} userID - most recent ID
      */
     async authenticateSRN(userID) {

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -125,7 +125,7 @@ export default {
         this.userIDList[0]["userID"] != ""
       );
     },
-    //checks if multiple entries are allowed and if one entry is already inputted
+    /** whether multiple entries have been made by the user */
     ifUserEnteredMoreThanOne() {
       return !this.isSingleEntryOnly && this.userIdListLength > 1;
     },

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -117,7 +117,7 @@ export default {
     userIdListLength() {
       return this.userIDList.length;
     },
-    //checks if any userID has been typed
+    /** checks if any userID has been entered */
     isAnyUserIDPresent() {
       return (
         this.userIDList != undefined &&

--- a/src/components/SRNEntry.vue
+++ b/src/components/SRNEntry.vue
@@ -183,7 +183,7 @@ export default {
       ];
     },
     /* checks to see if the input character is a number. Makes use of ASCII values.
-    @param {Event} - e - event triggered when a character is typed.  */
+    @param {Object} - e - event triggered when a character is typed.  */
     isValidNumericEntry(e) {
       if (e.keyCode >= 48 && e.keyCode <= 57) return true;
       else e.preventDefault();

--- a/src/services/API/checkUser.js
+++ b/src/services/API/checkUser.js
@@ -3,7 +3,7 @@ import { checkUserEndpoint } from "@/services/API/endpoints.js";
 
 export default {
     /**
-      * validates that the ID exists
+      * Validates that the ID exists
       * @param {String} inputUserID - the id that needs to be validated
       */
     checkUserExists(inputUserID)

--- a/src/services/API/checkUser.js
+++ b/src/services/API/checkUser.js
@@ -2,10 +2,10 @@ import {client} from "@/services/API/rootClient.js"
 import { checkUserEndpoint } from "@/services/API/endpoints.js";
 
 export default {
-    //checks if the user exists in the database or not
+    /* this method validates the ID against the database
+    @params {String} inputUserID - each ID being typed*/
     checkUserExists(inputUserID)
     {
-        //sending the entered userID to firebase for checking
         const params = {
             userID : inputUserID
         }

--- a/src/services/API/checkUser.js
+++ b/src/services/API/checkUser.js
@@ -2,8 +2,10 @@ import {client} from "@/services/API/rootClient.js"
 import { checkUserEndpoint } from "@/services/API/endpoints.js";
 
 export default {
-    /* this method validates the ID against the database
-    @params {String} inputUserID - each ID being typed*/
+    /**
+      * validates that the ID exists
+      * @param {String} inputUserID - the id that needs to be validated
+      */
     checkUserExists(inputUserID)
     {
         const params = {

--- a/src/services/API/rootClient.js
+++ b/src/services/API/rootClient.js
@@ -5,5 +5,5 @@ const headers = {
     'Content-Type': 'application/json',
   }
 
-//the base URL is the deployed cloud function URL
+/** the base URL is the deployed cloud function URL */
 export const client = axios.create({baseURL: 'https://us-central1-avantifellows.cloudfunctions.net'}, headers)

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -26,7 +26,7 @@ export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirec
       {
         dateTime: new Date(),
         purpose: {
-          type: "staging",
+          type: purpose,
           subType: purposeParams,
           params: {
             platform: redirectTo,

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -10,22 +10,23 @@ const sqsClient = new SQSClient({
   },
 });
 
-/* This function is used to send an SQS message to the queue on AWS. Makes use of the AWS SDK. (SendMessageCommand)
-@params {String} - purpose
-@params {String} - purposeParams
-@params {String} - redirectTo
-@params {String} - redirectID
-@params {Array} - userIDList - list of users wanting to go through the layer
-@params {String} - authType
-Everything, except the userIDList, is extracted from the auth layer URL
+/** This function is used to send an SQS message to the queue on AWS. 
+* @param {String} purpose
+* @param {String} purposeParams
+* @param {String} redirectTo
+* @param {String} redirectID
+* @param {Array} userIDList - list of users wanting to go through the layer
+* @param {String} authType
+* Everything, except the userIDList, is extracted from the auth layer URL
 */
+
 export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirectID, userIDList, authType) {
 
     const messageBody = [
       {
         dateTime: new Date(),
         purpose: {
-          type: purpose,
+          type: "staging",
           subType: purposeParams,
           params: {
             platform: redirectTo,

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -10,6 +10,15 @@ const sqsClient = new SQSClient({
   },
 });
 
+/* This function is used to send an SQS message to the queue on AWS. Makes use of the AWS SDK. (SendMessageCommand)
+@params {String} - purpose
+@params {String} - purposeParams
+@params {String} - redirectTo
+@params {String} - redirectID
+@params {Array} - userIDList - list of users wanting to go through the layer
+@params {String} - authType
+Everything, except the userIDList, is extracted from the auth layer URL
+*/
 export async function sendSQSMessage(purpose, purposeParams, redirectTo, redirectID, userIDList, authType) {
 
     const messageBody = [

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,6 +1,20 @@
 import { sendSQSMessage } from "@/services/API/sqs";
-//expects purposeParams, based on the value redirects to respective destination
 
+/* this is function is called when a user has to be redirected to the destination. Depending on the destination, the destination URL is built. 
+Following are the usecases so far:
+- if the destination is Plio, the url is built with the following:
+        - the Plio website's base URL (stored in environment variable)
+        - the Plio ID (from auth layer URL, redirectID)
+        - queryparams: Plio's API key (stored in environment variable) and unique ID (user ID) 
+- if the destination is a google meet class, the url is built with the following:
+        - the meet's base URL (stored in environment variable)
+        - the meeting ID (from auth layer URL, redirectID) 
+- if the destination is none of the above, then an SQS message with purpose = 'Error' is sent to keep a log of.
+@params {String} purposeparams - extracted from auth layer URL
+@params {Array} userIDList - list of userID's wanting to go through the layer 
+@params {String} redirectID - extracted from auth layer URL
+@params {String} redirectTo - extracted from auth layer URL
+@params {String} authType - extracted from auth layer URL */
 export function redirectToDestination(purposeParams, userIDList, redirectID, redirectTo, authType){
     var redirectURL = "";
     var fullurl = "";
@@ -8,10 +22,8 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
     switch(purposeParams){
         case 'plio':    
             var userID = userIDList[0]["userID"]
-            //constructs the URL based on the redirectTo param
             redirectURL = process.env.VUE_APP_BASE_URL_PLIO;
-            var url = new URL(redirectURL + redirectID); //adds plioID to the base plio link
-            //adds params; api key and student SRN
+            var url = new URL(redirectURL + redirectID); 
             var queryparams = new URLSearchParams({
                                 api_key: process.env.VUE_APP_AF_API_KEY,
                                 unique_id: userID,
@@ -19,15 +31,12 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
             fullurl = url + "?" + queryparams;
             break;
 
-        case 'liveclass':
-            //constructs the URL based on the redirectTo param
-            
+        case 'liveclass':           
             redirectURL = process.env.VUE_APP_BASE_URL_MEET;
-            fullurl = new URL(redirectURL + redirectID); //adds meetID to the base plio link
+            fullurl = new URL(redirectURL + redirectID);
             break;
         
         default:
-            //if destination is invalid, then send an error log into SQS.
             var purpose = 'Error'
             sendSQSMessage(
                 purpose,

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -5,7 +5,7 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
     var redirectURL = "";
     var fullurl = "";
     
-    switch(purposeParams){
+    switch(redirectTo){
         case 'plio':    
             var userID = userIDList[0]["userID"]
             //constructs the URL based on the redirectTo param
@@ -19,13 +19,17 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
             fullurl = url + "?" + queryparams;
             break;
 
-        case 'liveclass':
+        case 'meet':
             //constructs the URL based on the redirectTo param
             
             redirectURL = process.env.VUE_APP_BASE_URL_MEET;
             fullurl = new URL(redirectURL + redirectID); //adds meetID to the base plio link
             break;
         
+        case 'zoom':
+            fullurl = redirectID
+            break;
+            
         default:
             //if destination is invalid, then send an error log into SQS.
             var purpose = 'Error'

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,6 +1,6 @@
 import { sendSQSMessage } from "@/services/API/sqs";
 
-/** this is function is called when a user has to be redirected to the destination. Depending on the destination, the destination URL is built. 
+/** This is function is called when a user has to be redirected to the destination. Depending on the destination, the destination URL is built. 
 * @param {String} purposeparams - extracted from auth layer URL
 * @param {Array} userIDList - list of userID's wanting to go through the layer 
 * @param {String} redirectID - extracted from auth layer URL

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,20 +1,13 @@
 import { sendSQSMessage } from "@/services/API/sqs";
 
-/* this is function is called when a user has to be redirected to the destination. Depending on the destination, the destination URL is built. 
-Following are the usecases so far:
-- if the destination is Plio, the url is built with the following:
-        - the Plio website's base URL (stored in environment variable)
-        - the Plio ID (from auth layer URL, redirectID)
-        - queryparams: Plio's API key (stored in environment variable) and unique ID (user ID) 
-- if the destination is a google meet class, the url is built with the following:
-        - the meet's base URL (stored in environment variable)
-        - the meeting ID (from auth layer URL, redirectID) 
-- if the destination is none of the above, then an SQS message with purpose = 'Error' is sent to keep a log of.
-@params {String} purposeparams - extracted from auth layer URL
-@params {Array} userIDList - list of userID's wanting to go through the layer 
-@params {String} redirectID - extracted from auth layer URL
-@params {String} redirectTo - extracted from auth layer URL
-@params {String} authType - extracted from auth layer URL */
+/** this is function is called when a user has to be redirected to the destination. Depending on the destination, the destination URL is built. 
+* @param {String} purposeparams - extracted from auth layer URL
+* @param {Array} userIDList - list of userID's wanting to go through the layer 
+* @param {String} redirectID - extracted from auth layer URL
+* @param {String} redirectTo - extracted from auth layer URL
+* @param {String} authType - extracted from auth layer URL 
+*/
+
 export function redirectToDestination(purposeParams, userIDList, redirectID, redirectTo, authType){
     var redirectURL = "";
     var fullurl = "";

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -5,7 +5,7 @@ firebaseAPI service is used to validate and it returns a boolean value, indicati
 If the user is valid and validateCount = 0, then the function returns.
 If the user is not valid and validateCount = 0, then the user is not valid, so validateCount becomes 1 and login message displays an error, allowing the user to correct their entry.
 If the user is not valid and validateCount = 1, then the user has already been authenticated once before and the user has retyped, yet the entry is still invalid, then validateCount becomes 2 to indicate this behaviour.
-@params {String} - userID - current ID being authenticated 
+@params {String} - userID - the ID that needs to be validated 
 @params {Number} - validateCount - indicates how many times the user has been validated 
 @params {Boolean} - isCurrentUserValid - holds the value returned by the API */
 export async function validateSRN(userID, validateCount, isCurrentUserValid){

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,10 +1,9 @@
 import firebaseAPI from "@/services/API/checkUser.js";
 
-/** this function validates the entry against the database (for this usecase, it is firestore). 
+/** This function validates an entry against the database (for this usecase, it is firestore). 
 * firebaseAPI service is used to validate and it returns a boolean value, indicating whether the user is valid or not.
 * @param {String} userID - current ID being authenticated 
 * @param {Number} validateCount - indicates how many times the user has been validated 
-* @param {Boolean} isCurrentUserValid - holds the value returned by the API 
 */
 
 export async function validateSRN(userID, validateCount){

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,17 +1,16 @@
 import firebaseAPI from "@/services/API/checkUser.js";
 
-/* this function validates the entry against the database (for this usecase, it is firestore). 
-firebaseAPI service is used to validate and it returns a boolean value, indicating whether the user is valid or not.
-If the user is valid and validateCount = 0, then the function returns.
-If the user is not valid and validateCount = 0, then the user is not valid, so validateCount becomes 1 and login message displays an error, allowing the user to correct their entry.
-If the user is not valid and validateCount = 1, then the user has already been authenticated once before and the user has retyped, yet the entry is still invalid, then validateCount becomes 2 to indicate this behaviour.
-@params {String} - userID - current ID being authenticated 
-@params {Number} - validateCount - indicates how many times the user has been validated 
-@params {Boolean} - isCurrentUserValid - holds the value returned by the API */
-export async function validateSRN(userID, validateCount, isCurrentUserValid){
+/** this function validates the entry against the database (for this usecase, it is firestore). 
+* firebaseAPI service is used to validate and it returns a boolean value, indicating whether the user is valid or not.
+* @param {String} userID - current ID being authenticated 
+* @param {Number} validateCount - indicates how many times the user has been validated 
+* @param {Boolean} isCurrentUserValid - holds the value returned by the API 
+*/
+
+export async function validateSRN(userID, validateCount){
     var invalidLoginMessage = ""
 
-    isCurrentUserValid = await firebaseAPI.checkUserExists(userID);
+    var isCurrentUserValid = await firebaseAPI.checkUserExists(userID);
     if(isCurrentUserValid){
         return {
             isCurrentUserValid: isCurrentUserValid,
@@ -20,12 +19,12 @@ export async function validateSRN(userID, validateCount, isCurrentUserValid){
             }
         }
 
-    if (!isCurrentUserValid && validateCount == 0) {
+    if (validateCount == 0) {
         validateCount = 1;
         invalidLoginMessage = "Please enter correct SRN / कृपया सही SRN दर्ज करें";
     }
 
-    else if(!isCurrentUserValid && validateCount == 1){
+    else if(validateCount == 1){
         validateCount = 2;
     }
     return {

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -9,7 +9,7 @@ import firebaseAPI from "@/services/API/checkUser.js";
 export async function validateSRN(userID, validateCount){
     var invalidLoginMessage = ""
 
-    var isCurrentUserValid = await firebaseAPI.checkUserExists(userID);
+    let isCurrentUserValid = await firebaseAPI.checkUserExists(userID);
     if(isCurrentUserValid){
         return {
             isCurrentUserValid: isCurrentUserValid,

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -1,34 +1,35 @@
 import firebaseAPI from "@/services/API/checkUser.js";
 
-export async function validateSRN(userID, validateCount, isUserValid){
-    // this function is invoked only for the check of SRN's.
-    // validateCount = 0, when the user gets validated on the first try
-    // validateCount = 1, when the user fails the first check
-    // validateCount = 2, when user fails the second check as well -> letting the user go through irrespective.
-    
+/* this function validates the entry against the database (for this usecase, it is firestore). 
+firebaseAPI service is used to validate and it returns a boolean value, indicating whether the user is valid or not.
+If the user is valid and validateCount = 0, then the function returns.
+If the user is not valid and validateCount = 0, then the user is not valid, so validateCount becomes 1 and login message displays an error, allowing the user to correct their entry.
+If the user is not valid and validateCount = 1, then the user has already been authenticated once before and the user has retyped, yet the entry is still invalid, then validateCount becomes 2 to indicate this behaviour.
+@params {String} - userID - current ID being authenticated 
+@params {Number} - validateCount - indicates how many times the user has been validated 
+@params {Boolean} - isCurrentUserValid - holds the value returned by the API */
+export async function validateSRN(userID, validateCount, isCurrentUserValid){
     var invalidLoginMessage = ""
 
-    isUserValid = await firebaseAPI.checkUserExists(userID);
-    if(isUserValid){
+    isCurrentUserValid = await firebaseAPI.checkUserExists(userID);
+    if(isCurrentUserValid){
         return {
-            isUserValid: isUserValid,
+            isCurrentUserValid: isCurrentUserValid,
             validateCount: validateCount,
             invalidLoginMessage: invalidLoginMessage
             }
         }
 
-
-    // this condition checks if the user is getting authenticated the first time. Just shows an error message.
-    if (!isUserValid && validateCount == 0) {
+    if (!isCurrentUserValid && validateCount == 0) {
         validateCount = 1;
         invalidLoginMessage = "Please enter correct SRN / कृपया सही SRN दर्ज करें";
     }
-    // this condition checks if the user is getting authenticated the second time. 
-    else if(!isUserValid && validateCount == 1){
+
+    else if(!isCurrentUserValid && validateCount == 1){
         validateCount = 2;
     }
     return {
-        isUserValid: isUserValid,
+        isCurrentUserValid: isCurrentUserValid,
         validateCount: validateCount,
         invalidLoginMessage: invalidLoginMessage
     }


### PR DESCRIPTION
- Every time a user types incorrect SRN, the user is displayed with a login error. But we did not have any information about whether the user continued to attempt a second time or even if they did, what the initial attempt was.
- This code does the check every time an SRN is authenticated. Only if it is an invalid entry and if it is the first time, send an SQS message. 
- Added a new `purpose-sub-type` : `'incorrect-entry'`

A minor change: clearing the input field if the input entered is incorrect.