### PR TITLE
Added Zoom as a destination

### DIFF
--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -5,7 +5,7 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
     var redirectURL = "";
     var fullurl = "";
     
-    switch(purposeParams){
+    switch(redirectTo){
         case 'plio':    
             var userID = userIDList[0]["userID"]
             //constructs the URL based on the redirectTo param
@@ -19,13 +19,17 @@ export function redirectToDestination(purposeParams, userIDList, redirectID, red
             fullurl = url + "?" + queryparams;
             break;
 
-        case 'liveclass':
+        case 'meet':
             //constructs the URL based on the redirectTo param
             
             redirectURL = process.env.VUE_APP_BASE_URL_MEET;
             fullurl = new URL(redirectURL + redirectID); //adds meetID to the base plio link
             break;
         
+        case 'zoom':
+            fullurl = redirectID
+            break;
+            
         default:
             //if destination is invalid, then send an error log into SQS.
             var purpose = 'Error'


### PR DESCRIPTION
So far we were supporting only Plio and Google Meet as destinations. Now Zoom is added. 
The only difference is the way the URL looks. In the case of zoom, the `redirectID` will contain the entire meeting link as opposed to just the meeting ID. `(purpose=attendance&redirectTo=zoom&redirectID=https://us02web.zoom.us/j/88909631765&subPurpose=liveclass)`
The reason is there is no part of the URL that is constant. 
The only change in the code:
- The switch parameter is changed from `purposeParams` to `redirectTo`. Because in the case of meet and zoom, the `purposeParams` is always `liveclass`. 
