### PR TITLE
Re-send OTP

### DIFF
--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -38,7 +38,7 @@
         class="border-2 rounded-sm p-4 mx-auto border-gray-500 focus:border-gray-800 focus:outline-none"
         :class="selectInputBoxClasses"
         @input="updatePhoneNumber($event)"
-        :disabled="isOTPSent"
+        :disabled="isPhoneNumberNotEditable"
       />
     </div>
 
@@ -119,6 +119,7 @@ import {
 } from "@/services/OTPCodes.js";
 
 const RESEND_OTP_TIME_OUT = 60;
+
 export default {
   name: "OTP",
   props: {
@@ -295,6 +296,15 @@ export default {
         seconds = `0${seconds}`;
       }
       return `${minutes}:${seconds}`;
+    },
+
+    /** Whether the user can change the phone number.
+     * The user can't change the input either
+     * - when the OTP has been already sent
+     * - when countdown isn't finished
+     */
+    isPhoneNumberNotEditable() {
+      return this.isOTPSent || !this.isCountdownFinished;
     },
   },
   watch: {

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -87,10 +87,7 @@
     }}</span>
 
     <!-- timer for resending OTP -->
-    <p
-      v-show="hasCountdownStarted"
-      class="text-sm sm:text-md md:text-md lg:text-l xl:text-xl mx-auto font-bold px-6"
-    >
+    <p v-show="hasCountdownStarted" class="mx-auto font-bold px-6">
       {{ resendOTPText }}
       {{ formattedResendTimer }}
     </p>
@@ -304,7 +301,7 @@ export default {
      * - when countdown isn't finished
      */
     isPhoneNumberNotEditable() {
-      return this.isOTPSent || !this.isCountdownFinished;
+      return this.isOTPSent && (!this.isCountdownFinished || this.hasCountdownStarted);
     },
   },
   watch: {

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -139,7 +139,7 @@ export default {
       displayOTPMessage: [{ message: "", status: "" }], // string that contains any messages returned by the OTP service
       invalidPhoneNumberMessage: null, // whether the input being entered by the user matches a phone number format
       OTPResendButton: false, // whether OTP resend button should be shown
-      resendOTPTimer: 60, // seconds timer after when the resend OTP button needs to be displayed
+      resendOTPTimer: 60, // time in seconds after which the resend OTP button should be displayed
       OTPInterval: null, // to store the interval instance of the countdown timer
     };
   },

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -138,7 +138,7 @@ export default {
       displayOTPMessage: [{ message: "", status: "" }], // string that contains any messages returned by the OTP service
       invalidPhoneNumberMessage: null, // whether the input being entered by the user matches a phone number format
       isOTPResendButtonShown: false, // whether OTP resend button should be shown
-      resendOTPTimeLimit: RESEND_OTP_TIME_OUT, // seconds timer after when the resend OTP button needs to be displayed
+      resendOTPTimeLimit: RESEND_OTP_TIME_OUT, // time in seconds after which the resend OTP button should be displayed
       OTPInterval: null, // to store the interval instance of the countdown timer
     };
   },
@@ -298,9 +298,9 @@ export default {
   },
   watch: {
     /** Watches for the timer to finish */
-    resendOTPTimeLimit: function () {
-      if (this.resendOTPTimeLimit === 0) {
-        clearInterval(this.OTPInterval);
+    resendOTPTimer() {
+      if (this.resendOTPTimer === 0) {
+        clearInterval(this.interval);
       }
     },
   },

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -180,18 +180,10 @@ export default {
 
     /**
      * Whether the submit button is disabled
-     * Returns true if any of the following conditions are met:
-     * - if 'Request OTP' button is enabled
-     * - if 'Resend OTP' button is shown
-     * and
-     * - if OTP hasn't been typed yet
-     *
+     * Returns true if OTP hasn't been typed yet
      */
     isSubmitButtonDisabled() {
-      return (
-        this.OTPCode.length === 0 &&
-        (!this.isRequestOTPButtonDisabled || this.isOTPResendButtonShown)
-      );
+      return this.OTPCode.length === 0;
     },
 
     /** Checks if the current input entry has the required number of characters */

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -288,12 +288,11 @@ export default {
     },
 
     /** Whether the user can change the phone number.
-     * The user can't change the input either
-     * - when the OTP has been already sent
-     * - when countdown isn't finished
+     * The user can't change the input
+     * if the OTP has been sent and if the resend button timer hasn't started
      */
     isPhoneNumberNotEditable() {
-      return this.isOTPSent && (!this.isCountdownFinished || this.hasCountdownStarted);
+      return this.isOTPSent && this.hasCountdownStarted;
     },
   },
   watch: {

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -231,7 +231,7 @@ export default {
       return this.programData.text.default.invalid.input;
     },
 
-    /** 
+    /**
      * Whether to display the OTP response message.
      * It will not be displayed if the resend OTP timer is finished and will be replaced by the resend OTP button
      */

--- a/src/components/OTP.vue
+++ b/src/components/OTP.vue
@@ -231,8 +231,9 @@ export default {
       return this.programData.text.default.invalid.input;
     },
 
-    /** Whether OTP message will be displayed.
-     * Will not be displayed if the timer is finished. Will be replaced by the resend OTP button
+    /** 
+     * Whether to display the OTP response message.
+     * It will not be displayed if the resend OTP timer is finished and will be replaced by the resend OTP button
      */
     isOTPMessageDisplayed() {
       if (this.resendOTPTimeLimit === 0) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -74,10 +74,6 @@ export default {
     };
   },
   computed: {
-    /** Whether multiple ID can be entered */
-    isMultipleIDEntryAllowed() {
-      return this.redirectTo == "plio";
-    },
     /** Whether authentication method chosen is an ID entry */
     isAuthTypeID() {
       return this.authType == "ID";


### PR DESCRIPTION
- Logic for re-send OTP button.
- Essentially the backend call is still /sendOTP. 
- On the frontend, the re-send button is shown after 1 minute. The timer runs on screen. 