### PR TITLE
Checks for end date of the session

### DIFF
--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -71,7 +71,7 @@ export default {
       return year + '-' + month + '-' + date;
     },
 
-    /** Checks if current date is greater than start date and combines session start date and start time */
+    /** Checks if current date is greater than start date and combines current date and start time */
     sessionStartDateTime() {
       return (
         this.sessionData.startDate <= this.currentDate &&
@@ -79,11 +79,11 @@ export default {
       );
     },
 
-    /** Checks if current date is less than end date and combines session end date and end time */
+    /** Checks if current date is less than end date and combines current date and end time */
     sessionEndDateTime() {
       if ('endDate' in this.sessionData) {
         return (
-          this.sessionData.endDate > this.currentDate &&
+          this.sessionData.endDate >= this.currentDate &&
           new Date(this.currentDate + ' ' + this.sessionData.endTime)
         );
       }

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -28,15 +28,15 @@
 </template>
 
 <script>
-import NoClassMessage from './NoClassMessage.vue';
-import Entry from './Entry.vue';
-import groupAPIService from '@/services/API/groupData';
-import useAssets from '@/assets/assets.js';
+import NoClassMessage from "./NoClassMessage.vue";
+import Entry from "./Entry.vue";
+import groupAPIService from "@/services/API/groupData";
+import useAssets from "@/assets/assets.js";
 
 const assets = useAssets();
 const EXTRA_5_MINUTES = 900000;
 export default {
-  name: 'SessionEntry',
+  name: "SessionEntry",
   components: {
     NoClassMessage,
     Entry,
@@ -63,31 +63,31 @@ export default {
     currentDate() {
       let year = this.currentDateTime.getFullYear().toString();
       let month =
-        (this.currentDateTime.getMonth() + 1 < 9 ? '0' : '') +
+        (this.currentDateTime.getMonth() + 1 < 9 ? "0" : "") +
         (this.currentDateTime.getMonth() + 1).toString();
       let date =
-        (this.currentDateTime.getDate() + 1 < 9 ? '0' : '') +
+        (this.currentDateTime.getDate() + 1 < 9 ? "0" : "") +
         this.currentDateTime.getDate().toString();
-      return year + '-' + month + '-' + date;
+      return year + "-" + month + "-" + date;
     },
 
     /** Checks if current date is greater than start date and combines current date and start time */
     sessionStartDateTime() {
       return (
         this.sessionData.startDate <= this.currentDate &&
-        new Date(this.currentDate + ' ' + this.sessionData.startTime)
+        new Date(this.currentDate + " " + this.sessionData.startTime)
       );
     },
 
     /** Checks if current date is less than end date and combines current date and end time */
     sessionEndDateTime() {
-      if ('endDate' in this.sessionData) {
+      if ("endDate" in this.sessionData) {
         return (
           this.sessionData.endDate >= this.currentDate &&
-          new Date(this.currentDate + ' ' + this.sessionData.endTime)
+          new Date(this.currentDate + " " + this.sessionData.endTime)
         );
       }
-      return new Date(this.currentDate + ' ' + this.sessionData.endTime);
+      return new Date(this.currentDate + " " + this.sessionData.endTime);
     },
 
     /** Retrieves destination platform */
@@ -107,7 +107,7 @@ export default {
 
     /** Returns authentication method based on user's choice. For now, only ID is supported. */
     authType() {
-      return 'ID';
+      return "ID";
     },
 
     /** Returns the purpose value stored in session data */
@@ -138,8 +138,8 @@ export default {
 
     /** Checks if the session scheduled day matches the current day */
     isRepeatScheduleValid() {
-      if ('repeatSchedule' in this.sessionData) {
-        if (this.sessionData.repeatSchedule.type == 'weekly') {
+      if ("repeatSchedule" in this.sessionData) {
+        if (this.sessionData.repeatSchedule.type == "weekly") {
           return this.sessionData.repeatSchedule.params.includes(
             this.currentDateTime.getDay()
           );

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -84,7 +84,7 @@ export default {
       if ("endDate" in this.sessionData) {
         return (
           this.sessionData.endDate >= this.currentDate &&
-          new Date(this.currentDate + " " + this.sessionData.endTime)
+          new Date(this.sessionData.endDate + " " + this.sessionData.endTime)
         );
       }
       return new Date(this.currentDate + " " + this.sessionData.endTime);

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -159,8 +159,9 @@ export default {
     /** Sets the sessionActive variable based on the validity of the start time, end time and schedule */
     if (
       !(
-        (this.isStartDateTimeValid && this.isEndDateTimeValid)
-        // this.isRepeatScheduleValid
+        this.isStartDateTimeValid &&
+        this.isEndDateTimeValid &&
+        this.isRepeatScheduleValid
       )
     )
       this.sessionActive = false;

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -71,7 +71,7 @@ export default {
       return year + '-' + month + '-' + date;
     },
 
-    /** Combines session start date and start time */
+    /** Checks if current date is greater than start date and combines session start date and start time */
     sessionStartDateTime() {
       return (
         this.sessionData.startDate <= this.currentDate &&
@@ -79,7 +79,7 @@ export default {
       );
     },
 
-    /** Combines session end date and end time */
+    /** Checks if current date is less than end date and combines session end date and end time */
     sessionEndDateTime() {
       if ('endDate' in this.sessionData) {
         return (

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -28,15 +28,15 @@
 </template>
 
 <script>
-import NoClassMessage from "./NoClassMessage.vue";
-import Entry from "./Entry.vue";
-import groupAPIService from "@/services/API/groupData";
-import useAssets from "@/assets/assets.js";
+import NoClassMessage from './NoClassMessage.vue';
+import Entry from './Entry.vue';
+import groupAPIService from '@/services/API/groupData';
+import useAssets from '@/assets/assets.js';
 
 const assets = useAssets();
 const EXTRA_5_MINUTES = 900000;
 export default {
-  name: "SessionEntry",
+  name: 'SessionEntry',
   components: {
     NoClassMessage,
     Entry,
@@ -63,31 +63,31 @@ export default {
     currentDate() {
       let year = this.currentDateTime.getFullYear().toString();
       let month =
-        (this.currentDateTime.getMonth() + 1 < 9 ? "0" : "") +
+        (this.currentDateTime.getMonth() + 1 < 9 ? '0' : '') +
         (this.currentDateTime.getMonth() + 1).toString();
       let date =
-        (this.currentDateTime.getDate() + 1 < 9 ? "0" : "") +
+        (this.currentDateTime.getDate() + 1 < 9 ? '0' : '') +
         this.currentDateTime.getDate().toString();
-      return year + "-" + month + "-" + date;
+      return year + '-' + month + '-' + date;
     },
 
     /** Combines session start date and start time */
     sessionStartDateTime() {
       return (
         this.sessionData.startDate <= this.currentDate &&
-        new Date(this.currentDate + " " + this.sessionData.startTime)
+        new Date(this.currentDate + ' ' + this.sessionData.startTime)
       );
     },
 
     /** Combines session end date and end time */
     sessionEndDateTime() {
-      if ("endDate" in this.sessionData) {
+      if ('endDate' in this.sessionData) {
         return (
           this.sessionData.endDate > this.currentDate &&
-          new Date(this.currentDate + " " + this.sessionData.endTime)
+          new Date(this.currentDate + ' ' + this.sessionData.endTime)
         );
       }
-      return new Date(this.currentDate + " " + this.sessionData.endTime);
+      return new Date(this.currentDate + ' ' + this.sessionData.endTime);
     },
 
     /** Retrieves destination platform */
@@ -107,7 +107,7 @@ export default {
 
     /** Returns authentication method based on user's choice. For now, only ID is supported. */
     authType() {
-      return "ID";
+      return 'ID';
     },
 
     /** Returns the purpose value stored in session data */
@@ -138,9 +138,8 @@ export default {
 
     /** Checks if the session scheduled day matches the current day */
     isRepeatScheduleValid() {
-      console.log("repeatSchedule" in this.sessionData);
-      if ("repeatSchedule" in this.sessionData) {
-        if (this.sessionData.repeatSchedule.type == "weekly") {
+      if ('repeatSchedule' in this.sessionData) {
+        if (this.sessionData.repeatSchedule.type == 'weekly') {
           return this.sessionData.repeatSchedule.params.includes(
             this.currentDateTime.getDay()
           );

--- a/src/components/SessionEntry.vue
+++ b/src/components/SessionEntry.vue
@@ -1,12 +1,12 @@
 <template>
-<div v-if="isLoading">
-<div class="flex m-auto w-full h-full">
+  <div v-if="isLoading">
+    <div class="flex m-auto w-full h-full">
       <inline-svg
         class="text-black text-4xl m-auto animate-spin h-20 w-20"
         :src="loadingSpinnerSvg"
       />
     </div>
-    </div>
+  </div>
 
   <!-- User message -->
   <div v-if="!sessionActive">
@@ -31,109 +31,138 @@
 import NoClassMessage from "./NoClassMessage.vue";
 import Entry from "./Entry.vue";
 import groupAPIService from "@/services/API/groupData";
-import useAssets from '@/assets/assets.js'
+import useAssets from "@/assets/assets.js";
 
 const assets = useAssets();
-const EXTRA_5_MINUTES = 900000
+const EXTRA_5_MINUTES = 900000;
 export default {
   name: "SessionEntry",
-  components:{
+  components: {
     NoClassMessage,
-    Entry
+    Entry,
   },
   props: {
     sessionData: {
       type: Object,
       default() {
-        return {}
-      }
+        return {};
+      },
     },
   },
-  data(){
+  data() {
     return {
-      sessionActive : true, // whether the timings between the session and user match
+      sessionActive: true, // whether the timings between the session and user match
       groupData: null, //stores details about the group
-      currentDateTime : new Date(), // user's current date and time
+      currentDateTime: new Date(), // user's current date and time
       isLoading: false,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
-    }
+    };
   },
-  computed:{
+  computed: {
     /** Returns formatted local date of the user  */
-    currentDate(){
-      let year = this.currentDateTime.getFullYear().toString()
-      let month = (((this.currentDateTime.getMonth() + 1) < 9) ? '0' : '') + (this.currentDateTime.getMonth() + 1).toString()
-      let date = (((this.currentDateTime.getDate() + 1) < 9) ? '0' : '') + (this.currentDateTime.getDate()).toString()
-      return (year + '-' + month + '-' + date)
+    currentDate() {
+      let year = this.currentDateTime.getFullYear().toString();
+      let month =
+        (this.currentDateTime.getMonth() + 1 < 9 ? "0" : "") +
+        (this.currentDateTime.getMonth() + 1).toString();
+      let date =
+        (this.currentDateTime.getDate() + 1 < 9 ? "0" : "") +
+        this.currentDateTime.getDate().toString();
+      return year + "-" + month + "-" + date;
     },
 
     /** Combines session start date and start time */
-    sessionStartDateTime(){
-      return (this.sessionData.startDate <= this.currentDate ) && (new Date(this.currentDate + " " + this.sessionData.startTime))
+    sessionStartDateTime() {
+      return (
+        this.sessionData.startDate <= this.currentDate &&
+        new Date(this.currentDate + " " + this.sessionData.startTime)
+      );
     },
 
     /** Combines session end date and end time */
-    sessionEndDateTime(){
-      return (new Date(this.currentDate + " " + this.sessionData.endTime))
+    sessionEndDateTime() {
+      if ("endDate" in this.sessionData) {
+        return (
+          this.sessionData.endDate > this.currentDate &&
+          new Date(this.currentDate + " " + this.sessionData.endTime)
+        );
+      }
+      return new Date(this.currentDate + " " + this.sessionData.endTime);
     },
 
     /** Retrieves destination platform */
-    redirectTo(){
-      return this.sessionData.redirectPlatform
+    redirectTo() {
+      return this.sessionData.redirectPlatform;
     },
 
     /** Retrieves destination ID */
-    redirectId(){
-      return this.sessionData.redirectPlatformParams.id
+    redirectId() {
+      return this.sessionData.redirectPlatformParams.id;
     },
 
     /** Retrieves group name */
-    group(){
-      return this.sessionData.group
+    group() {
+      return this.sessionData.group;
     },
 
     /** Returns authentication method based on user's choice. For now, only ID is supported. */
-    authType(){
-      return "ID"
+    authType() {
+      return "ID";
     },
 
     /** Returns the purpose value stored in session data */
-    purpose(){
-      return this.sessionData.purpose
+    purpose() {
+      return this.sessionData.purpose;
     },
 
     /** Returns the purpose params stored in session data */
-    purposeParams(){
-      return this.sessionData.purposeParams
+    purposeParams() {
+      return this.sessionData.purposeParams;
     },
 
     /** Checks if the session has begun */
-    isStartDateTimeValid(){
-      return this.getSessionDateTimeInMilliseconds(this.sessionStartDateTime) <= Date.parse(this.currentDateTime) + EXTRA_5_MINUTES
+    isStartDateTimeValid() {
+      return (
+        this.getSessionDateTimeInMilliseconds(this.sessionStartDateTime) <=
+        Date.parse(this.currentDateTime) + EXTRA_5_MINUTES
+      );
     },
 
     /** Checks if the session has ended */
-    isEndDateTimeValid(){
-       console.log(this.currentDateTime, Date.parse(this.currentDateTime), this.sessionEndDateTime, this.getSessionDateTimeInMilliseconds(this.sessionEndDateTime))
-      return Date.parse(this.currentDateTime) <= this.getSessionDateTimeInMilliseconds(this.sessionEndDateTime)
+    isEndDateTimeValid() {
+      return (
+        Date.parse(this.currentDateTime) <=
+        this.getSessionDateTimeInMilliseconds(this.sessionEndDateTime)
+      );
     },
 
     /** Checks if the session scheduled day matches the current day */
-    isRepeatScheduleValid(){
-      if(this.sessionData.repeatSchedule.type == "weekly"){
-          return this.sessionData.repeatSchedule.params.includes(this.currentDateTime.getDay())
+    isRepeatScheduleValid() {
+      console.log("repeatSchedule" in this.sessionData);
+      if ("repeatSchedule" in this.sessionData) {
+        if (this.sessionData.repeatSchedule.type == "weekly") {
+          return this.sessionData.repeatSchedule.params.includes(
+            this.currentDateTime.getDay()
+          );
+        }
+        return false;
       }
-      return false
+      return true;
     },
 
     /** Retrieves session ID */
-    sessionId(){
-      return this.sessionData.id
-    }
+    sessionId() {
+      return this.sessionData.id;
+    },
   },
-  async created(){
+  async created() {
     /** Sets the sessionActive variable based on the validity of the start time, end time and schedule */
-    if(!(this.isStartDateTimeValid &&  this.isEndDateTimeValid && this.isRepeatScheduleValid))
+    if (
+      !(
+        (this.isStartDateTimeValid && this.isEndDateTimeValid)
+        // this.isRepeatScheduleValid
+      )
+    )
       this.sessionActive = false;
     this.isLoading = true;
     this.groupData = await groupAPIService.getGroupData(this.group);
@@ -141,9 +170,9 @@ export default {
   },
   methods: {
     /** Parses datetime string into milliseconds */
-    getSessionDateTimeInMilliseconds(datetime){
-      return Date.parse(JSON.parse(JSON.stringify(datetime)))
+    getSessionDateTimeInMilliseconds(datetime) {
+      return Date.parse(JSON.parse(JSON.stringify(datetime)));
     },
-  }
+  },
 };
 </script>


### PR DESCRIPTION
**Apologies for the unnecessary formatting changes. The eslint config is different across repos. Finding a solution to standarize across.**

This code adds two checks:
- Checks if `endDate` exists in the session data. If yes, check if the current date is less than or equal to the end date and combines the current date with the session end time to create the current day's end guard.  
- Added a check if `repeatSchedule` exists in the session data. If not, it is a non-repeating schedule and ignores the check. 