### PR TITLE
Display an error toast if backend shows error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.30.0",
-    "@sentry/tracing": "^6.16.1",
-    "@sentry/vue": "^6.16.1",
     "autoprefixer": "^9.8.6",
     "axios": "^0.21.1",
     "buffer": "^6.0.3",
@@ -27,7 +25,8 @@
     "vue-inline-svg": "^3.1.0",
     "vue-router": "^4.0.10",
     "vuex": "^4.0.2",
-    "vuex-persistedstate": "^4.1.0"
+    "vuex-persistedstate": "^4.1.0",
+    "vue-toastification": "^2.0.0-rc.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.30.0",
+    "@sentry/tracing": "^6.16.1",
+    "@sentry/vue": "^6.16.1",
     "autoprefixer": "^9.8.6",
     "axios": "^0.21.1",
     "buffer": "^6.0.3",

--- a/src/main.js
+++ b/src/main.js
@@ -6,11 +6,14 @@ import App from "./App.vue";
 import router from "./router";
 import store from "./store";
 import "./index.css";
+import Toast from "vue-toastification";
+import "vue-toastification/dist/index.css";
 
 const app = createApp(App)
   .component("inline-svg", InlineSvg)
   .use(router)
-  .use(store);
+  .use(store)
+  .use(Toast);
 
 if (["staging", "production"].includes(import.meta.env.MODE)) {
   Sentry.init({

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -182,7 +182,7 @@ export default {
 
       if (this.sessionEnabled)
         this.groupData = await groupAPIService.getGroupData(this.getGroup);
-      if (!this.sessionData.error && this.groupData.error) {
+      if (!this.sessionData.error && this.groupData && this.groupData.error) {
         // GroupAPI returns an error
         this.toast.error("Network Error, please try again!", {
           position: "top-center",

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -47,8 +47,10 @@ import groupAPIService from "@/services/API/groupData.js";
 import sessionAPIService from "@/services/API/sessionData.js";
 import NoClassMessage from "@/components/NoClassMessage.vue";
 import useAssets from "@/assets/assets.js";
+import { useToast } from "vue-toastification";
 
 const assets = useAssets();
+
 export default {
   name: "Home",
   components: {
@@ -100,6 +102,7 @@ export default {
       sessionEnabled: true, // whether a session is enabled
       isLoading: true,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
+      toast: useToast(),
     };
   },
   computed: {
@@ -161,11 +164,34 @@ export default {
           },
         });
       }
-      this.sessionEnabled = this.sessionData.sessionActive;
-    }
+      console.log(this.sessionData.error);
+      if (this.sessionData.error) {
+        this.toast.error("Network Error, please try again!", {
+          position: "top-center",
+          timeout: false,
+          closeOnClick: false,
+          draggable: false,
+          closeButton: false,
+        });
+      } else {
+        this.toast.clear();
+        this.sessionEnabled = this.sessionData.sessionActive
+          ? this.sessionData.sessionActive
+          : this.sessionEnabled;
+      }
 
-    if (this.sessionEnabled)
-      this.groupData = await groupAPIService.getGroupData(this.getGroup);
+      if (this.sessionEnabled)
+        this.groupData = await groupAPIService.getGroupData(this.getGroup);
+      if (!this.sessionData.error && this.groupData.error) {
+        this.toast.error("Network Error, please try again!", {
+          position: "top-center",
+          timeout: false,
+          closeOnClick: false,
+          draggable: false,
+          closeButton: false,
+        });
+      }
+    }
     this.isLoading = false;
   },
 };

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -153,11 +153,11 @@ export default {
     /** If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data. */
     if (this.sessionId != null) {
       this.sessionData = await sessionAPIService.getSessionData(this.sessionId);
-      // Session ID does not exist
+      // // Session ID does not exist
       if (Object.keys(this.sessionData).length == 0) {
         this.$router.push({
           name: "Error",
-          params: {
+          state: {
             text:
               "There is no session scheduled with this ID. Please contact your Program Manager.",
           },
@@ -179,7 +179,6 @@ export default {
           this.sessionEnabled = this.sessionData.sessionActive;
         }
       }
-      console.log(this.sessionEnabled, this.sessionData.sessionActive);
       if (this.sessionEnabled)
         this.groupData = await groupAPIService.getGroupData(this.getGroup);
       if (!this.sessionData.error && this.groupData && this.groupData.error) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -50,7 +50,6 @@ import useAssets from "@/assets/assets.js";
 import { useToast } from "vue-toastification";
 
 const assets = useAssets();
-
 export default {
   name: "Home",
   components: {
@@ -164,7 +163,7 @@ export default {
           },
         });
       }
-      console.log(this.sessionData.error);
+      // SessionAPI returns an error
       if (this.sessionData.error) {
         this.toast.error("Network Error, please try again!", {
           position: "top-center",
@@ -183,6 +182,7 @@ export default {
       if (this.sessionEnabled)
         this.groupData = await groupAPIService.getGroupData(this.getGroup);
       if (!this.sessionData.error && this.groupData.error) {
+        // GroupAPI returns an error
         this.toast.error("Network Error, please try again!", {
           position: "top-center",
           timeout: false,

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -153,7 +153,7 @@ export default {
     /** If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data. */
     if (this.sessionId != null) {
       this.sessionData = await sessionAPIService.getSessionData(this.sessionId);
-      // // Session ID does not exist
+      // Session ID does not exist
       if (Object.keys(this.sessionData).length == 0) {
         this.$router.push({
           name: "Error",

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -163,6 +163,7 @@ export default {
           },
         });
       }
+
       // SessionAPI returns an error
       if (this.sessionData.error) {
         this.toast.error("Network Error, please try again!", {
@@ -174,9 +175,9 @@ export default {
         });
       } else {
         this.toast.clear();
-        this.sessionEnabled = this.sessionData.sessionActive
-          ? this.sessionData.sessionActive
-          : this.sessionEnabled;
+        if ("sessionActive" in this.sessionData) {
+          this.sessionEnabled = this.sessionData.sessionActive;
+        }
       }
 
       if (this.sessionEnabled)

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -179,7 +179,7 @@ export default {
           this.sessionEnabled = this.sessionData.sessionActive;
         }
       }
-
+      console.log(this.sessionEnabled, this.sessionData.sessionActive);
       if (this.sessionEnabled)
         this.groupData = await groupAPIService.getGroupData(this.getGroup);
       if (!this.sessionData.error && this.groupData && this.groupData.error) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -157,7 +157,7 @@ export default {
       if (Object.keys(this.sessionData).length == 0) {
         this.$router.push({
           name: "Error",
-          state: {
+          params: {
             text:
               "There is no session scheduled with this ID. Please contact your Program Manager.",
           },

--- a/src/services/API/checkUser.js
+++ b/src/services/API/checkUser.js
@@ -19,6 +19,10 @@ export default {
         .post(checkUserEndpoint, JSON.stringify(params))
         .then((response) => {
           resolve(response.data);
+        })
+        .catch((error) => {
+          resolve({ error: error });
+          throw new Error("User API returned an error:", error);
         });
     });
   },

--- a/src/services/API/groupData.js
+++ b/src/services/API/groupData.js
@@ -18,6 +18,7 @@ export default {
         })
         .catch((error) => {
           resolve({ error: error });
+          throw new Error("Group API returned an error:", error);
         });
     });
   },

--- a/src/services/API/groupData.js
+++ b/src/services/API/groupData.js
@@ -15,6 +15,9 @@ export default {
         .post(getGroupDataEndpoint, JSON.stringify(params))
         .then((response) => {
           resolve(response.data);
+        })
+        .catch((error) => {
+          resolve({ error: error });
         });
     });
   },

--- a/src/services/API/sessionData.js
+++ b/src/services/API/sessionData.js
@@ -18,6 +18,7 @@ export default {
         })
         .catch((error) => {
           resolve({ error: error });
+          throw new Error("Session API returned an error:", error);
         });
     });
   },

--- a/src/services/API/sessionData.js
+++ b/src/services/API/sessionData.js
@@ -15,6 +15,9 @@ export default {
         .post(getSessionDataEndpoint, JSON.stringify(params))
         .then((response) => {
           resolve(response.data);
+        })
+        .catch((error) => {
+          resolve({ error: error });
         });
     });
   },

--- a/src/services/validation.js
+++ b/src/services/validation.js
@@ -36,7 +36,15 @@ async function checkUserIdInFirestore(
     collectionName,
     columnName
   );
-
+  if (isCurrentUserValid.error) {
+    this.toast.error("Network Error, please try again!", {
+      position: "top-center",
+      timeout: false,
+      closeOnClick: false,
+      draggable: false,
+      closeButton: false,
+    });
+  }
   if (isCurrentUserValid) {
     return {
       isCurrentUserValid: isCurrentUserValid,


### PR DESCRIPTION
- A toast pops up whenever an API call fails.
- Errors are logged to Sentry as well.

![Screenshot 2022-09-02 at 3 01 42 PM](https://user-images.githubusercontent.com/25496389/188110238-f2993e6e-a47f-4d06-ae7d-f95b383a1bba.png)
