### PR TITLE
Send user's IP address

### DIFF
--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -126,6 +126,10 @@ export default {
       type: String,
       default: "",
     },
+    userData: {
+      type: Object,
+      default: {},
+    },
   },
   data() {
     return {
@@ -459,7 +463,8 @@ export default {
             this.authType,
             this.group,
             this.userType,
-            this.sessionId
+            this.sessionId,
+            this.userData
           );
         }
       }

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -126,9 +126,9 @@ export default {
       type: String,
       default: "",
     },
-    userNetworkData: {
-      type: Object,
-      default: {},
+    userIpAddress: {
+      type: String,
+      default: "",
     },
   },
   data() {
@@ -464,7 +464,7 @@ export default {
             this.group,
             this.userType,
             this.sessionId,
-            this.userNetworkData
+            this.userIpAddress
           );
         }
       }

--- a/src/components/Entry.vue
+++ b/src/components/Entry.vue
@@ -126,7 +126,7 @@ export default {
       type: String,
       default: "",
     },
-    userData: {
+    userNetworkData: {
       type: Object,
       default: {},
     },
@@ -464,7 +464,7 @@ export default {
             this.group,
             this.userType,
             this.sessionId,
-            this.userData
+            this.userNetworkData
           );
         }
       }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -23,7 +23,7 @@
         :group="getGroup"
         :authType="authType"
         :sessionId="sessionId"
-        :userNetworkData="getUserNetworkData"
+        :userIpAddress="getUserIpAddress"
       />
     </div>
     <!-- OTP component -->
@@ -103,7 +103,7 @@ export default {
       isLoading: true,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
       toast: useToast(),
-      userNetworkData: {}, // contains network data of the user
+      getUserIpAddress: "", // contains network data of the user
     };
   },
   computed: {
@@ -151,8 +151,8 @@ export default {
         : this.purposeParams;
     },
 
-    /** Returns object containing network data about the user */
-    getUserNetworkData() {
+    /** Returns IP address of user */
+    getUserIpAddress() {
       return { userIp: this.sessionData.userIp };
     },
   },

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -103,7 +103,7 @@ export default {
       isLoading: true,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
       toast: useToast(),
-      getUserIpAddress: "", // contains network data of the user
+      getUserIpAddress: "", // contains IP address of the user
     };
   },
   computed: {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -23,6 +23,7 @@
         :group="getGroup"
         :authType="authType"
         :sessionId="sessionId"
+        :userData="getUserData"
       />
     </div>
     <!-- OTP component -->
@@ -102,6 +103,7 @@ export default {
       isLoading: true,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
       toast: useToast(),
+      userData: {},
     };
   },
   computed: {
@@ -147,6 +149,9 @@ export default {
       return this.purposeParams == ""
         ? this.sessionData.purposeParams
         : this.purposeParams;
+    },
+    getUserData() {
+      return { userIp: this.sessionData.userIp };
     },
   },
   async created() {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -23,7 +23,7 @@
         :group="getGroup"
         :authType="authType"
         :sessionId="sessionId"
-        :userData="getUserData"
+        :userNetworkData="getUserNetworkData"
       />
     </div>
     <!-- OTP component -->
@@ -103,7 +103,7 @@ export default {
       isLoading: true,
       loadingSpinnerSvg: assets.loadingSpinnerSvg,
       toast: useToast(),
-      userData: {},
+      userNetworkData: {}, // contains network data of the user
     };
   },
   computed: {
@@ -150,7 +150,9 @@ export default {
         ? this.sessionData.purposeParams
         : this.purposeParams;
     },
-    getUserData() {
+
+    /** Returns object containing network data about the user */
+    getUserNetworkData() {
       return { userIp: this.sessionData.userIp };
     },
   },

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -29,7 +29,8 @@ export async function sendSQSMessage(
   authType,
   groupName,
   userType,
-  sessionId
+  sessionId,
+  userData
 ) {
   const messageBody = [
     {
@@ -49,6 +50,7 @@ export async function sendSQSMessage(
       group: groupName,
       userType: userType,
       sessionId: sessionId,
+      userData: userData,
     },
   ];
   const params = {

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -30,7 +30,7 @@ export async function sendSQSMessage(
   groupName,
   userType,
   sessionId,
-  userNetworkData
+  userIpAddress
 ) {
   const messageBody = [
     {
@@ -50,7 +50,7 @@ export async function sendSQSMessage(
       group: groupName,
       userType: userType,
       sessionId: sessionId,
-      userNetworkData: userNetworkData,
+      userIpAddress: userIpAddress,
     },
   ];
   const params = {

--- a/src/services/API/sqs.js
+++ b/src/services/API/sqs.js
@@ -30,7 +30,7 @@ export async function sendSQSMessage(
   groupName,
   userType,
   sessionId,
-  userData
+  userNetworkData
 ) {
   const messageBody = [
     {
@@ -50,7 +50,7 @@ export async function sendSQSMessage(
       group: groupName,
       userType: userType,
       sessionId: sessionId,
-      userData: userData,
+      userNetworkData: userNetworkData,
     },
   ];
   const params = {


### PR DESCRIPTION
- The IP address is sent from the backend because you can extract the address only through a request call. 
- `userNetworkData` is the object that contains all network data about the user. The next item will be the device details.

Test the below session and after redirection, check the BQ table. 
https://staging-auth.avantifellows.org/?sessionId=HaryanaStudents_B01_44672_vfr-mndk-ado
https://console.cloud.google.com/bigquery?authuser=0&project=avantifellows&ws=!1m10!1m4!4m3!1savantifellows!2sauth_logs!3sstaging-attendance-logs!1m4!1m3!1savantifellows!2sbquxjob_3dbcb634_183c099d63f!3sasia-south1