### PR TITLE
Remove autofill of dependant fields

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -55,6 +55,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    defaultValue: {
+      type: String,
+      default: "",
+    },
   },
   data() {
     return {

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -62,9 +62,6 @@ export default {
     };
   },
   watch: {
-    options() {
-      this.value = this.options[0];
-    },
     /**
      * Emits 'update' event whenever the dropdown value is changed
      */

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,6 @@ import Toast from "vue-toastification";
 import "vue-toastification/dist/index.css";
 import { plugin, defaultConfig } from "@formkit/vue";
 import { createLocalStoragePlugin } from "@formkit/addons";
-import "@formkit/themes/genesis";
 
 const app = createApp(App)
   .component("inline-svg", InlineSvg)

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -437,12 +437,11 @@ export default {
   },
   async created() {
     this.$store.dispatch("setLocale", "en");
-
     /**
      * If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data.
      */
     if (this.sessionId != "") {
-      if (this.sessionId.startsWith("HaryanaStudents")) {
+      if (this.sessionId.startsWith("EnableStudents")) {
         this.oldFlow = false;
         this.sessionData = await sessionAPIService.getSessionData(
           this.sessionId

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -465,29 +465,29 @@ export default {
       // }
 
       /** Session API returns an error*/
-      if (this.sessionData.error) {
-        this.toast.error("Network Error, please try again!", {
-          position: "top-center",
-          timeout: false,
-          closeOnClick: false,
-          draggable: false,
-          closeButton: false,
-        });
-      } else {
-        /** Store session data retrieved by API and set sessionEnabled */
-        this.toast.clear();
-        this.$store.dispatch("setSessionData", this.sessionData);
+      // if (this.sessionData.error) {
+      //   this.toast.error("Network Error, please try again!", {
+      //     position: "top-center",
+      //     timeout: false,
+      //     closeOnClick: false,
+      //     draggable: false,
+      //     closeButton: false,
+      //   });
+      // } else {
+      //   /** Store session data retrieved by API and set sessionEnabled */
+      //   this.toast.clear();
+      //   this.$store.dispatch("setSessionData", this.sessionData);
 
-        if (this.oldFlow) {
-          if ("sessionActive" in this.sessionData) {
-            this.sessionEnabled = this.sessionData.sessionActive;
-          }
-        } else {
-          if ("is_session_open" in this.sessionData) {
-            this.sessionEnabled = this.sessionData.is_session_open;
-          }
-        }
-      }
+      //   if (this.oldFlow) {
+      //     if ("sessionActive" in this.sessionData) {
+      //       this.sessionEnabled = this.sessionData.sessionActive;
+      //     }
+      //   } else {
+      //     if ("is_session_open" in this.sessionData) {
+      //       this.sessionEnabled = this.sessionData.is_session_open;
+      //     }
+      //   }
+      // }
 
       /** If session is open, retrieve group data and store it */
       //   if (!this.sessionData.error && this.sessionEnabled) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -441,6 +441,7 @@ export default {
      * If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data.
      */
     if (this.sessionId != "") {
+      console.log(this.sessionId, this.sessionId.startsWith("EnableStudents"))
       if (this.sessionId.startsWith("EnableStudents")) {
         console.log(this.sessionId);
         this.oldFlow = false;

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -441,9 +441,7 @@ export default {
      * If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data.
      */
     if (this.sessionId != "") {
-      console.log(this.sessionId, this.sessionId.startsWith("EnableStudents"));
       if (this.sessionId.startsWith("EnableStudents")) {
-        console.log(this.sessionId);
         this.oldFlow = false;
         this.sessionData = await sessionAPIService.getSessionData(
           this.sessionId
@@ -455,86 +453,86 @@ export default {
       }
 
       /** SessionId does not exist */
-      // if (Object.keys(this.sessionData).length == 0) {
-      //   this.$router.push({
-      //     name: "Error",
-      //     params: {
-      //       text: "There is no session scheduled with this ID. Please contact your Program Manager.",
-      //     },
-      //   });
-      // }
+      if (Object.keys(this.sessionData).length == 0) {
+        this.$router.push({
+          name: "Error",
+          params: {
+            text: "There is no session scheduled with this ID. Please contact your Program Manager.",
+          },
+        });
+      }
 
       /** Session API returns an error*/
-      // if (this.sessionData.error) {
-      //   this.toast.error("Network Error, please try again!", {
-      //     position: "top-center",
-      //     timeout: false,
-      //     closeOnClick: false,
-      //     draggable: false,
-      //     closeButton: false,
-      //   });
-      // } else {
-      //   /** Store session data retrieved by API and set sessionEnabled */
-      //   this.toast.clear();
-      //   this.$store.dispatch("setSessionData", this.sessionData);
-
-      //   if (this.oldFlow) {
-      //     if ("sessionActive" in this.sessionData) {
-      //       this.sessionEnabled = this.sessionData.sessionActive;
-      //     }
-      //   } else {
-      //     if ("is_session_open" in this.sessionData) {
-      //       this.sessionEnabled = this.sessionData.is_session_open;
-      //     }
-      //   }
-      // }
-
-      /** If session is open, retrieve group data and store it */
-      //   if (!this.sessionData.error && this.sessionEnabled) {
-      //     if (!this.oldFlow) {
-      //       this.groupData = await groupAPIService.getGroupName(
-      //         this.sessionData.id
-      //       );
-      //     } else {
-      //       this.groupData = await groupAPIService.getGroupData(
-      //         this.sessionData.group
-      //       );
-      //     }
-      //     this.$store.dispatch("setGroupData", this.groupData);
-      //     if (!this.sessionData.error && this.groupData && this.groupData.error) {
-      //       /** Group API returns an error*/
-      //       this.toast.error("Network Error, please try again!", {
-      //         position: "top-center",
-      //         timeout: false,
-      //         closeOnClick: false,
-      //         draggable: false,
-      //         closeButton: false,
-      //       });
-      //     }
-      //   }
-      // } else {
-      //   if (this.platform == "gurukul") {
-      //     this.oldFlow = false;
-      //   }
-      //   /**
-      //    * If sessionId does not exist in route, then retrieve group data directly
-      //    */
-      //   if (!this.oldFlow) {
-      //     this.groupData = await groupAPIService.getNewGroupData(this.group);
-      //   } else {
-      //     this.groupData = await groupAPIService.getGroupData(this.getGroup);
-      //   }
-      //   this.$store.dispatch("setGroupData", this.groupData);
-      //if (this.groupData && this.groupData.error) {
-      /** Group API returns an error*/
-      /** this.toast.error("Network Error, please try again!", {
+      if (this.sessionData.error) {
+        this.toast.error("Network Error, please try again!", {
           position: "top-center",
           timeout: false,
           closeOnClick: false,
           draggable: false,
           closeButton: false,
         });
-      } */
+      } else {
+        /** Store session data retrieved by API and set sessionEnabled */
+        this.toast.clear();
+        this.$store.dispatch("setSessionData", this.sessionData);
+
+        if (this.oldFlow) {
+          if ("sessionActive" in this.sessionData) {
+            this.sessionEnabled = this.sessionData.sessionActive;
+          }
+        } else {
+          if ("is_session_open" in this.sessionData) {
+            this.sessionEnabled = this.sessionData.is_session_open;
+          }
+        }
+      }
+
+      /** If session is open, retrieve group data and store it */
+      if (!this.sessionData.error && this.sessionEnabled) {
+        if (!this.oldFlow) {
+          this.groupData = await groupAPIService.getGroupName(
+            this.sessionData.id
+          );
+        } else {
+          this.groupData = await groupAPIService.getGroupData(
+            this.sessionData.group
+          );
+        }
+        this.$store.dispatch("setGroupData", this.groupData);
+        if (!this.sessionData.error && this.groupData && this.groupData.error) {
+          /** Group API returns an error*/
+          this.toast.error("Network Error, please try again!", {
+            position: "top-center",
+            timeout: false,
+            closeOnClick: false,
+            draggable: false,
+            closeButton: false,
+          });
+        }
+      }
+    } else {
+      if (this.platform == "gurukul") {
+        this.oldFlow = false;
+      }
+      /**
+       * If sessionId does not exist in route, then retrieve group data directly
+       */
+      if (!this.oldFlow) {
+        this.groupData = await groupAPIService.getNewGroupData(this.group);
+      } else {
+        this.groupData = await groupAPIService.getGroupData(this.getGroup);
+      }
+      this.$store.dispatch("setGroupData", this.groupData);
+      if (this.groupData && this.groupData.error) {
+        /** Group API returns an error*/
+        this.toast.error("Network Error, please try again!", {
+          position: "top-center",
+          timeout: false,
+          closeOnClick: false,
+          draggable: false,
+          closeButton: false,
+        });
+      }
     }
     this.isLoading = false;
     this.isIdGenerationEnabled;

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -441,7 +441,7 @@ export default {
      * If sessionId exists in route, then retrieve session details. Otherwise, fallback to using group data.
      */
     if (this.sessionId != "") {
-      console.log(this.sessionId, this.sessionId.startsWith("EnableStudents"))
+      console.log(this.sessionId, this.sessionId.startsWith("EnableStudents"));
       if (this.sessionId.startsWith("EnableStudents")) {
         console.log(this.sessionId);
         this.oldFlow = false;
@@ -490,44 +490,44 @@ export default {
       }
 
       /** If session is open, retrieve group data and store it */
-      if (!this.sessionData.error && this.sessionEnabled) {
-        if (!this.oldFlow) {
-          this.groupData = await groupAPIService.getGroupName(
-            this.sessionData.id
-          );
-        } else {
-          this.groupData = await groupAPIService.getGroupData(
-            this.sessionData.group
-          );
-        }
-        this.$store.dispatch("setGroupData", this.groupData);
-        if (!this.sessionData.error && this.groupData && this.groupData.error) {
-          /** Group API returns an error*/
-          this.toast.error("Network Error, please try again!", {
-            position: "top-center",
-            timeout: false,
-            closeOnClick: false,
-            draggable: false,
-            closeButton: false,
-          });
-        }
-      }
-    } else {
-      if (this.platform == "gurukul") {
-        this.oldFlow = false;
-      }
-      /**
-       * If sessionId does not exist in route, then retrieve group data directly
-       */
-      if (!this.oldFlow) {
-        this.groupData = await groupAPIService.getNewGroupData(this.group);
-      } else {
-        this.groupData = await groupAPIService.getGroupData(this.getGroup);
-      }
-      this.$store.dispatch("setGroupData", this.groupData);
+      //   if (!this.sessionData.error && this.sessionEnabled) {
+      //     if (!this.oldFlow) {
+      //       this.groupData = await groupAPIService.getGroupName(
+      //         this.sessionData.id
+      //       );
+      //     } else {
+      //       this.groupData = await groupAPIService.getGroupData(
+      //         this.sessionData.group
+      //       );
+      //     }
+      //     this.$store.dispatch("setGroupData", this.groupData);
+      //     if (!this.sessionData.error && this.groupData && this.groupData.error) {
+      //       /** Group API returns an error*/
+      //       this.toast.error("Network Error, please try again!", {
+      //         position: "top-center",
+      //         timeout: false,
+      //         closeOnClick: false,
+      //         draggable: false,
+      //         closeButton: false,
+      //       });
+      //     }
+      //   }
+      // } else {
+      //   if (this.platform == "gurukul") {
+      //     this.oldFlow = false;
+      //   }
+      //   /**
+      //    * If sessionId does not exist in route, then retrieve group data directly
+      //    */
+      //   if (!this.oldFlow) {
+      //     this.groupData = await groupAPIService.getNewGroupData(this.group);
+      //   } else {
+      //     this.groupData = await groupAPIService.getGroupData(this.getGroup);
+      //   }
+      //   this.$store.dispatch("setGroupData", this.groupData);
       //if (this.groupData && this.groupData.error) {
-        /** Group API returns an error*/
-       /** this.toast.error("Network Error, please try again!", {
+      /** Group API returns an error*/
+      /** this.toast.error("Network Error, please try again!", {
           position: "top-center",
           timeout: false,
           closeOnClick: false,

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -442,6 +442,7 @@ export default {
      */
     if (this.sessionId != "") {
       if (this.sessionId.startsWith("EnableStudents")) {
+        console.log(this.sessionId);
         this.oldFlow = false;
         this.sessionData = await sessionAPIService.getSessionData(
           this.sessionId

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -455,14 +455,14 @@ export default {
       }
 
       /** SessionId does not exist */
-      if (Object.keys(this.sessionData).length == 0) {
-        this.$router.push({
-          name: "Error",
-          params: {
-            text: "There is no session scheduled with this ID. Please contact your Program Manager.",
-          },
-        });
-      }
+      // if (Object.keys(this.sessionData).length == 0) {
+      //   this.$router.push({
+      //     name: "Error",
+      //     params: {
+      //       text: "There is no session scheduled with this ID. Please contact your Program Manager.",
+      //     },
+      //   });
+      // }
 
       /** Session API returns an error*/
       if (this.sessionData.error) {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -525,16 +525,16 @@ export default {
         this.groupData = await groupAPIService.getGroupData(this.getGroup);
       }
       this.$store.dispatch("setGroupData", this.groupData);
-      if (this.groupData && this.groupData.error) {
+      //if (this.groupData && this.groupData.error) {
         /** Group API returns an error*/
-        this.toast.error("Network Error, please try again!", {
+       /** this.toast.error("Network Error, please try again!", {
           position: "top-center",
           timeout: false,
           closeOnClick: false,
           draggable: false,
           closeButton: false,
         });
-      }
+      } */
     }
     this.isLoading = false;
     this.isIdGenerationEnabled;

--- a/src/pages/InformationForm.vue
+++ b/src/pages/InformationForm.vue
@@ -16,6 +16,7 @@
         :label="formField.label[getLocale]"
         :isRequired="formField.required"
         :dbKey="formField.key"
+        :defaultValue="formField.defaultValue"
         :options="formField.options[getLocale]"
         :multiple="formField.multiple"
         :maxLengthOfEntry="formField.maxLengthOfEntry"
@@ -129,16 +130,24 @@ export default {
       return Object.keys(this.formSchemaData).forEach((field) => {
         let fieldAttributes = this.formSchemaData[field];
         let showBasedOn = fieldAttributes.showBasedOn;
+        let showBasedOnCondition = fieldAttributes.showBasedOnCondition;
 
         if (fieldAttributes.showBasedOn != "") {
           if (
             this.userData[Object.keys(JSON.parse(showBasedOn))] ==
-            Object.values(JSON.parse(showBasedOn))[0]
+            Object.values(JSON.parse(showBasedOn))
+          ) {
+            fieldAttributes["show"] = true;
+          } else fieldAttributes["show"] = false;
+        }
+        if (fieldAttributes.dependant) {
+          if (
+            fieldAttributes.dependantField in this.userData &&
+            this.userData[fieldAttributes.dependantField] != ""
           ) {
             fieldAttributes["show"] = true;
           } else {
             fieldAttributes["show"] = false;
-            this.userData[fieldAttributes.key] = "";
           }
         }
       });

--- a/src/pages/NewSignin.vue
+++ b/src/pages/NewSignin.vue
@@ -19,7 +19,7 @@
     <div
       v-for="(authType, index) in auth_type"
       :key="`id-${index}`"
-      class="mx-auto"
+      class="mx-auto w-56 my-2"
     >
       <NumberEntry
         v-if="isEntryNumber(authType)"

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -66,15 +66,11 @@
     v-if="formSubmitted"
     class="w-5/6 lg:w-1/2 mx-auto flex flex-col text-center mt-20 justify-evenly text-lg md:text-xl p-6 space-y-6"
   >
-    <div class="bg-primary-hover py-10 rounded-md shadow-sm">
-      <p>{{ idGeneratedText }}</p>
-      <!-- <p>
-        <b>Your ID is {{ userData["user_id"] }}</b>
-      </p>
-      <p>
-        Kindly make a note of it. You will need this to log in to all your
-        future sessions.
-      </p> -->
+    <div
+      v-if="userData['user_id'] != '' || userData['user_id'] != undefined"
+      class="bg-primary-hover py-10 rounded-md shadow-sm"
+    >
+      <p v-html="idGeneratedText" />
     </div>
 
     <button
@@ -160,9 +156,9 @@ export default {
     /** Returns text based on locale */
     idGeneratedText() {
       return this.getLocale == "en"
-        ? `Your ID is + this.userData["user_id"]. + <br/> Kindly make a note of it. You will need this to log in to all your
+        ? `Your ID is <b> ${this.userData["user_id"]}.</b>  <br/> Kindly make a note of it. You will need this to log in to all your
         future sessions.`
-        : `आपकी आईडी + this.userData["user_id"] +  है + <br/> कृपया इसे नोट कर लीजिए। भविष्य में साइन-इन करने के लिए इसी आईडी का उपयोग करें।`;
+        : `आपकी आईडी <b> ${this.userData["user_id"]}</b> है|  <br/> कृपया इसे नोट कर लीजिए। भविष्य में साइन-इन करने के लिए इसी आईडी का उपयोग करें।`;
     },
     /** returns title for the form */
     formTitle() {

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -239,7 +239,11 @@ export default {
         ) {
           console.log(
             this.formData.attributes[field].key,
-            this.userData.hasOwnProperty(this.formData.attributes[field].key)
+            this.userData.hasOwnProperty(this.formData.attributes[field].key),
+            this.formData.attributes[field].required,
+            this.formData.attributes[field].show,
+            this.userData[this.formData.attributes[field].key],
+            this.userData[this.formData.attributes[field].key] == ""
           );
           isUserDataComplete = false;
         }

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -111,6 +111,7 @@ export default {
     this.formData = await FormSchemaAPI.getFormSchema(
       this.$store.state.sessionData.form_schema_id
     );
+
     Object.keys(this.formData.attributes).forEach((field) => {
       this.formData.attributes[field]["component"] =
         typeToInputParameters[this.formData.attributes[field].type];

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -193,21 +193,21 @@ export default {
         let showBasedOnCondition = fieldAttributes.showBasedOnCondition;
 
         if (fieldAttributes.showBasedOn != "") {
-          if (showBasedOnCondition == "IS") {
-            if (
-              this.userData[Object.keys(JSON.parse(showBasedOn))] ==
-              Object.values(JSON.parse(showBasedOn))
-            ) {
-              fieldAttributes["show"] = true;
-            } else fieldAttributes["show"] = false;
-          } else if (showBasedOnCondition == "IS NOT") {
-            if (
-              Object.keys(JSON.parse(showBasedOn)) in this.userData &&
-              this.userData[Object.keys(JSON.parse(showBasedOn))] !=
-                Object.values(JSON.parse(showBasedOn))
-            ) {
-              fieldAttributes["show"] = true;
-            } else fieldAttributes["show"] = false;
+          if (
+            this.userData[Object.keys(JSON.parse(showBasedOn))] ==
+            Object.values(JSON.parse(showBasedOn))
+          ) {
+            fieldAttributes["show"] = true;
+          } else fieldAttributes["show"] = false;
+        }
+        if (fieldAttributes.dependant) {
+          if (
+            fieldAttributes.dependantField in this.userData &&
+            this.userData[fieldAttributes.dependantField] != ""
+          ) {
+            fieldAttributes["show"] = true;
+          } else {
+            fieldAttributes["show"] = false;
           }
         }
       });

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -237,6 +237,10 @@ export default {
           this.formData.attributes[field].required &&
           this.formData.attributes[field].show
         ) {
+          console.log(
+            this.formData.attributes[field].key,
+            this.userData.hasOwnProperty(this.formData.attributes[field].key)
+          );
           isUserDataComplete = false;
         }
       });

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -31,13 +31,13 @@
         :show="formField.show"
         :key="index"
         :is="formField.component"
-        :label="formField.label[locale]"
+        :label="formField.label[getLocale]"
         :isRequired="formField.required"
         :dbKey="formField.key"
-        :options="formField.options[locale]"
+        :options="formField.options[getLocale]"
         :multiple="formField.multiple"
         :maxLengthOfEntry="formField.maxLengthOfEntry"
-        :helpText="formField.helpText[locale]"
+        :helpText="formField.helpText[getLocale]"
         @update="updateUserData"
         class="mt-[25px]"
       />
@@ -67,13 +67,14 @@
     class="w-5/6 lg:w-1/2 mx-auto flex flex-col text-center mt-20 justify-evenly text-lg md:text-xl p-6 space-y-6"
   >
     <div class="bg-primary-hover py-10 rounded-md shadow-sm">
-      <p>
+      <p>{{ idGeneratedText }}</p>
+      <!-- <p>
         <b>Your ID is {{ userData["user_id"] }}</b>
       </p>
       <p>
         Kindly make a note of it. You will need this to log in to all your
         future sessions.
-      </p>
+      </p> -->
     </div>
 
     <button
@@ -136,7 +137,7 @@ export default {
   computed: {
     /** Returns button text */
     signUpButtonLabel() {
-      return this.locale == "en" ? "Sign Up" : "साइन अप";
+      return this.getLocale == "en" ? "Sign Up" : "साइन अप";
     },
 
     /** Returns button text */
@@ -151,11 +152,18 @@ export default {
 
     /** Returns text based on locale */
     signInText() {
-      return this.locale == "en"
+      return this.getLocale == "en"
         ? "Already Registered? <b> Sign In</b>"
         : "पहले ही रजिस्टर्ड हैं? <b>साइन इन करें। </b>";
     },
 
+    /** Returns text based on locale */
+    idGeneratedText() {
+      return this.getLocale == "en"
+        ? `Your ID is + this.userData["user_id"]. + <br/> Kindly make a note of it. You will need this to log in to all your
+        future sessions.`
+        : `आपकी आईडी + this.userData["user_id"] +  है + <br/> कृपया इसे नोट कर लीजिए। भविष्य में साइन-इन करने के लिए इसी आईडी का उपयोग करें।`;
+    },
     /** returns title for the form */
     formTitle() {
       return this.formData.name;
@@ -182,14 +190,25 @@ export default {
       return Object.keys(this.formData.attributes).forEach((field) => {
         let fieldAttributes = this.formData.attributes[field];
         let showBasedOn = fieldAttributes.showBasedOn;
+        let showBasedOnCondition = fieldAttributes.showBasedOnCondition;
 
         if (fieldAttributes.showBasedOn != "") {
-          if (
-            this.userData[Object.keys(JSON.parse(showBasedOn))] ==
-            Object.values(JSON.parse(showBasedOn))
-          ) {
-            fieldAttributes["show"] = true;
-          } else fieldAttributes["show"] = false;
+          if (showBasedOnCondition == "IS") {
+            if (
+              this.userData[Object.keys(JSON.parse(showBasedOn))] ==
+              Object.values(JSON.parse(showBasedOn))
+            ) {
+              fieldAttributes["show"] = true;
+            } else fieldAttributes["show"] = false;
+          } else if (showBasedOnCondition == "IS NOT") {
+            if (
+              Object.keys(JSON.parse(showBasedOn)) in this.userData &&
+              this.userData[Object.keys(JSON.parse(showBasedOn))] !=
+                Object.values(JSON.parse(showBasedOn))
+            ) {
+              fieldAttributes["show"] = true;
+            } else fieldAttributes["show"] = false;
+          }
         }
       });
     },
@@ -205,9 +224,9 @@ export default {
               fieldAttributes.dependantFieldMapping[
                 this.userData[fieldAttributes.dependantField]
               ];
-            return fieldAttributes.options[this.locale];
           }
         }
+        return fieldAttributes.options[this.getLocale];
       });
     },
 

--- a/src/pages/NewSignup.vue
+++ b/src/pages/NewSignup.vue
@@ -67,7 +67,11 @@
     class="w-5/6 lg:w-1/2 mx-auto flex flex-col text-center mt-20 justify-evenly text-lg md:text-xl p-6 space-y-6"
   >
     <div
-      v-if="userData['user_id'] != '' || userData['user_id'] != undefined"
+      v-if="
+        userData['user_id'] != '' ||
+        userData['user_id'] != undefined ||
+        userData['user_id'] != 'undefined'
+      "
       class="bg-primary-hover py-10 rounded-md shadow-sm"
     >
       <p v-html="idGeneratedText" />
@@ -237,14 +241,6 @@ export default {
           this.formData.attributes[field].required &&
           this.formData.attributes[field].show
         ) {
-          console.log(
-            this.formData.attributes[field].key,
-            this.userData.hasOwnProperty(this.formData.attributes[field].key),
-            this.formData.attributes[field].required,
-            this.formData.attributes[field].show,
-            this.userData[this.formData.attributes[field].key],
-            this.userData[this.formData.attributes[field].key] == ""
-          );
           isUserDataComplete = false;
         }
       });


### PR DESCRIPTION
- Before, dependant field would get autofilled based on the values selected by the parent field. For example, if a value from region dropdown was selected, then the dependant values would be shown for the state field with the first value as selected. This could lead to incorrect data because the user could skip the field thinking it is filled without confirming the result. 
- Now, the child field is hidden until the parent field is filled in. It is shown only if the parent field is completed.

https://staging-auth.avantifellows.org/?sessionId=EnableStudents_E12EC_45156_izw-xtkh-tii