### PR TITLE
Redirect to Sashakt via portal launch endpoint

### DIFF
--- a/src/pages/Signup.vue
+++ b/src/pages/Signup.vue
@@ -236,6 +236,8 @@ export default {
       if (this.getLocale != "en") resultText = "सत्र शुरू करें";
       else {
         if (this.$store.state.platform == "quiz") resultText = "Start Quiz";
+        else if (this.$store.state.platform == "sashakt")
+          resultText = "Start Test";
         else if (this.$store.state.platform == "others")
           resultText = "Start Session";
         else if (this.$store.state.platform == "gurukul")

--- a/src/services/API/endpoints.js
+++ b/src/services/API/endpoints.js
@@ -16,3 +16,4 @@ export const getSchoolEndpoint = "/school";
 export const createAccessTokenEndpoint = "/auth/create-access-token";
 export const verifyTokenEndpoint = "/auth/verify";
 export const refreshTokenEndpoint = "/auth/refresh-token";
+export const createSashaktLaunchEndpoint = "/sashakt/launch";

--- a/src/services/API/sashakt.js
+++ b/src/services/API/sashakt.js
@@ -1,0 +1,12 @@
+import { fastAPIClient } from "./rootClient";
+import { createSashaktLaunchEndpoint } from "./endpoints";
+
+export default {
+  async createLaunch(data) {
+    const response = await fastAPIClient.post(
+      createSashaktLaunchEndpoint,
+      data
+    );
+    return response.data;
+  },
+};

--- a/src/services/redirectToDestination.js
+++ b/src/services/redirectToDestination.js
@@ -1,5 +1,6 @@
 import { sendSQSMessage } from "@/services/API/sqs";
 import TokenAPI from "@/services/API/token";
+import SashaktAPI from "@/services/API/sashakt";
 
 /** Redirects user to the appropriate destination platform
  * @param {String} userId - user ID for authentication
@@ -113,6 +114,21 @@ export async function redirectToDestination(
         launchToken,
       });
       fullURL = url + "?" + finalURLQueryParams;
+      break;
+    }
+    case "sashakt": {
+      const launchResponse = await SashaktAPI.createLaunch({
+        user_id: userId,
+        test_link_uuid: redirectId,
+        device_info: window.navigator?.userAgent || "Browser",
+      });
+
+      if (!launchResponse?.launch_url) {
+        console.error("Unable to create Sashakt launch", launchResponse);
+        return false;
+      }
+
+      fullURL = launchResponse.launch_url;
       break;
     }
     case "report": {


### PR DESCRIPTION
Add a sashakt redirect case that calls /sashakt/launch with the user_id and test link, then redirects the student to the returned Sashakt webapp launch URL. Sashakt resolves the recurring student to a stable candidate server-side.