### PR TITLE
fix(auth): scope student profile hydration to the auth group

### DIFF
--- a/src/services/API/user.js
+++ b/src/services/API/user.js
@@ -133,20 +133,24 @@ export default {
     });
   },
 
-  async getProfileForToken(userType, identifiers = {}) {
+  async getProfileForToken(userType, identifiers = {}, authGroup = null) {
     let endpoint = null;
     let params = null;
 
     if (userType === "student") {
       endpoint = getStudentEndpoint;
+      // `user_id` must only ever carry a real canonical user id. Falling back to
+      // student_id/apaar_id here sent a non-user_id value in the user_id slot, which the
+      // backend ANDs with the other filters - so the lookup matched nothing at all.
+      // student_id and apaar_id are already sent as their own params below.
       params = {
-        user_id:
-          identifiers.user_id ??
-          identifiers.student_id ??
-          identifiers.apaar_id ??
-          null,
+        user_id: identifiers.user_id ?? null,
         student_id: identifiers.student_id ?? null,
         apaar_id: identifiers.apaar_id ?? null,
+        // `student_id` is only unique within an auth group, so scope the lookup to the
+        // group the student is signing in through. Without this a student registered in
+        // more than one auth group can hydrate the wrong group's profile.
+        auth_group: authGroup ?? null,
       };
     } else if (userType === "teacher") {
       endpoint = getTeacherEndpoint;

--- a/src/services/hydrateAuthContext.js
+++ b/src/services/hydrateAuthContext.js
@@ -11,9 +11,12 @@ export async function buildHydratedAuthContext({
   let mergedUserInformation = userInformation;
 
   if (platform === "gurukul") {
+    // `group` is the auth group name; pass it through so a student_id that exists in
+    // more than one auth group hydrates the profile for the group being signed into.
     const hydratedProfile = await UserAPI.getProfileForToken(
       userType,
-      identifiers
+      identifiers,
+      group
     );
 
     if (hydratedProfile) {


### PR DESCRIPTION
## Why

Two bugs in the gurukul profile-hydration path (`getProfileForToken` → `GET /student`), found while tracing a student who could log into one auth group but not another.

### 1. The `user_id` fallback silently broke the lookup

```js
user_id:
  identifiers.user_id ??
  identifiers.student_id ??   // <-- not a user_id
  identifiers.apaar_id ??
  null,
student_id: identifiers.student_id ?? null,
apaar_id: identifiers.apaar_id ?? null,
```

When `user_id` was absent, a `student_id` went into the **`user_id` slot** — while `student_id` was *also* sent as its own param. The backend ANDs all supplied filters, so the request asked for a student whose `user_id` equals a student_id, which is never true.

Verified against production:

```
?user_id=8979364564&student_id=8979364564  ->  []          # matches nothing
?student_id=8979364564                     ->  2 records
```

So hydration silently returned nothing for any student without a real canonical `user_id`, and `getProfileForToken` swallowed it as `null`. `student_id` and `apaar_id` are already sent as their own params, so the fallback was never doing useful work — it only corrupted the query.

### 2. The lookup was not scoped to an auth group

`student_id` is only unique **within an auth group** now — db-service dropped the global unique index ([db-service#649](https://github.com/avantifellows/db-service/pull/649)) — so one `student_id` can legitimately resolve to several student records, one per auth group. Unscoped, hydration can load the **wrong group's profile**.

The auth group name was already available at every call site (`group: this.$store.state.authGroupData.name` in `Signin.vue` ×2 and `Signup.vue`) and passed into `buildHydratedAuthContext` — it just never got forwarded to the request.

## What

- `user_id` now only ever carries a real canonical user id — the `?? student_id ?? apaar_id` fallback is gone.
- `getProfileForToken` takes an `authGroup` argument and sends it as `auth_group`.
- `hydrateAuthContext` forwards the `group` it already receives.

Null params are still filtered before the request, so nothing is sent when the auth group is unknown.

## Verification

Against production, for a student registered in two auth groups:

```
BEFORE  user_id=8979364564&student_id=8979364564          ->  []
AFTER   student_id=8979364564&auth_group=UttarakhandStudents  ->  [(519352, 529877)]
AFTER   student_id=8979364564&auth_group=AllIndiaStudents     ->  [(490965, 500009)]
```

Broken → correct, and each auth group now hydrates its own record.

Single-auth-group students are unaffected — scoped and unscoped agree:

```
student_id=08463409&auth_group=PunjabStudents  ->  [(503059, 513579)]
student_id=08463409                            ->  [(503059, 513579)]
```

## Requires

The backend must accept `auth_group` on `GET /student` — **[avantifellows/portal-backend#91](https://github.com/avantifellows/portal-backend/pull/91)**. **Deploy that first**: `validate_and_build_query_params` rejects unknown query params with a 400, so shipping this frontend change ahead of #91 would turn profile hydration into a 400 (caught and logged as `null`, same visible outcome as today's silent failure, but noisier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
